### PR TITLE
Add dispatch to PaymentMethod

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.0.x-dev"
+			"dev-master": "1.1.x-dev"
 		}
 	}
 }

--- a/src/Domain/Model/BankTransferPayment.php
+++ b/src/Domain/Model/BankTransferPayment.php
@@ -8,7 +8,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class BankTransferPayment implements PaymentMethod {
+class BankTransferPayment extends BasePaymentMethod {
 
 	private $bankTransferCode;
 

--- a/src/Domain/Model/BasePaymentMethod.php
+++ b/src/Domain/Model/BasePaymentMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Domain\Model;
+
+abstract class BasePaymentMethod implements PaymentMethod {
+	/**
+	 * @param callable $callback
+	 * @return mixed|void
+	 */
+	public function dispatch( callable $callback ) {
+		return ( new PaymentMethodDispatcher( [ $this->getId() => $callback ] ) )->dispatch( $this );
+	}
+}

--- a/src/Domain/Model/CreditCardPayment.php
+++ b/src/Domain/Model/CreditCardPayment.php
@@ -8,7 +8,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class CreditCardPayment implements PaymentMethod {
+class CreditCardPayment extends BasePaymentMethod {
 
 	private $creditCardData;
 

--- a/src/Domain/Model/DirectDebitPayment.php
+++ b/src/Domain/Model/DirectDebitPayment.php
@@ -8,7 +8,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class DirectDebitPayment implements PaymentMethod {
+class DirectDebitPayment extends BasePaymentMethod {
 
 	private $bankData;
 

--- a/src/Domain/Model/PayPalPayment.php
+++ b/src/Domain/Model/PayPalPayment.php
@@ -8,7 +8,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class PayPalPayment implements PaymentMethod {
+class PayPalPayment extends BasePaymentMethod {
 
 	private $payPalData;
 

--- a/src/Domain/Model/PaymentMethod.php
+++ b/src/Domain/Model/PaymentMethod.php
@@ -21,4 +21,12 @@ interface PaymentMethod {
 	 */
 	public function getId(): string;
 
+	/**
+	 * Execute code for a specific payment method
+	 *
+	 * @param callable $callback
+	 * @return mixed
+	 */
+	public function dispatch( callable $callback );
+
 }

--- a/src/Domain/Model/PaymentMethodDispatcher.php
+++ b/src/Domain/Model/PaymentMethodDispatcher.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Domain\Model;
+
+class PaymentMethodDispatcher {
+	private $callbackTable;
+
+	/**
+	 * @param callable[] $callbackTable payment id => function
+	 */
+	public function __construct( array $callbackTable ) {
+		$this->callbackTable = $callbackTable;
+	}
+
+	public function dispatch( PaymentMethod $method ) {
+		if ( empty( $this->callbackTable[$method->getId()] ) ) {
+			return;
+		}
+		return call_user_func( $this->callbackTable[$method->getId()], $method );
+	}
+}

--- a/src/Domain/Model/PaymentWithoutAssociatedData.php
+++ b/src/Domain/Model/PaymentWithoutAssociatedData.php
@@ -8,7 +8,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class PaymentWithoutAssociatedData implements PaymentMethod {
+class PaymentWithoutAssociatedData extends BasePaymentMethod {
 
 	private $paymentMethod;
 

--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -6,7 +6,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
 
 use DateTime;
 
-class SofortPayment implements PaymentMethod {
+class SofortPayment extends BasePaymentMethod {
 
 	/**
 	 * @var string

--- a/tests/Fixtures/PaymentMethodStub.php
+++ b/tests/Fixtures/PaymentMethodStub.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Fixtures;
+
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentMethod;
+
+class PaymentMethodStub implements PaymentMethod {
+
+	public function getId(): string {
+		return 'TST';
+	}
+
+	public function dispatch( callable $callback ): void {
+	}
+}

--- a/tests/Unit/Domain/Model/PaymentMethodDispatcherTest.php
+++ b/tests/Unit/Domain/Model/PaymentMethodDispatcherTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentMethodDispatcher;
+use WMDE\Fundraising\PaymentContext\Tests\Fixtures\PaymentMethodStub;
+
+class PaymentMethodDispatcherTest extends TestCase {
+
+	public function testDispatchCallsMatchingDispatchFunction() {
+		$testPayment = new PaymentMethodStub();
+		$dispatcher = new PaymentMethodDispatcher( [
+			$testPayment->getId() => function ( PaymentMethodStub $payment ) use ( $testPayment ) {
+				$this->assertSame( $testPayment, $payment );
+			}
+		] );
+
+		$dispatcher->dispatch( $testPayment );
+	}
+
+	public function testDispatchChecksCallbackParameterForPaymentType() {
+		$testPayment = new PaymentMethodStub();
+		$dispatcher = new PaymentMethodDispatcher( [
+			$testPayment->getId() => function ( BankTransferPayment $payment ) {
+				$this->fail( 'This should not be called' );
+			}
+		] );
+
+		$this->expectException( \TypeError::class );
+		$dispatcher->dispatch( $testPayment );
+	}
+
+	public function testDispatchReturnsCallbackResult() {
+		$testPayment = new PaymentMethodStub();
+		$dispatcher = new PaymentMethodDispatcher( [
+			$testPayment->getId() => function ( PaymentMethodStub $payment ) {
+				return 'let me see';
+			}
+		] );
+
+		$this->assertSame( 'let me see', $dispatcher->dispatch( $testPayment ) );
+	}
+}

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -6,7 +6,10 @@ namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\Domain\Model\BasePaymentMethod;
+use WMDE\Fundraising\PaymentContext\Domain\Model\InvalidPaymentTypeException;
 use WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment;
+use WMDE\Fundraising\PaymentContext\Tests\Fixtures\PaymentMethodStub;
 
 class SofortPaymentTest extends TestCase {
 
@@ -32,5 +35,30 @@ class SofortPaymentTest extends TestCase {
 		$sofortPayment = new SofortPayment( 'ipsum' );
 		$sofortPayment->setConfirmedAt( new DateTime( 'now' ) );
 		$this->assertTrue( $sofortPayment->isConfirmedPayment() );
+	}
+
+	public function testDispatchCallsCallbackForSofortPaymentFunction(): void {
+		$sofortPayment = new SofortPayment( 'ipsum' );
+		$sofortPayment->dispatch( function ( SofortPayment $payment ) use ( $sofortPayment ) {
+			$this->assertSame( $sofortPayment, $payment, 'Payment should be callback parameter' );
+		} );
+	}
+
+	public function testDispatchReturnsCallbackResult(): void {
+		$sofortPayment = new SofortPayment( 'ipsum' );
+		$this->assertSame(
+			'success!',
+			$sofortPayment->dispatch( function ( SofortPayment $payment ) {
+				return 'success!';
+			} )
+		);
+	}
+
+	public function testDispatchThrowsForNonSofortPaymentFunction(): void {
+		$sofortPayment = new SofortPayment( 'ipsum' );
+		$this->expectException( \TypeError::class );
+		$sofortPayment->dispatch( function ( PaymentMethodStub $payment ) {
+			$this->fail( 'Callback should not be called' );
+		} );
 	}
 }


### PR DESCRIPTION
Enable type-safe access to PaymentMethod implementations.

Current code in the FundraisingFrontend and the domain repositories
makes assumptions about the payment type, using /** @var */ type hints
to placate static analysis, implicitly upcasting variables.
This patch enables a more strict type checking.

### Example 1 - Avoiding assumptions, make type explicit in code
Before:
```
/** @var PayPalPayment $method */
$method = $donation->getPaymentMethod();
$method->setPaypalData( $data );
```

After:
```
$donation->getPaymentMethod->dispatch(
    function( PaypalPayment $payment ) use ( $data ) {
        $payment->setPaypalData( $data );
    }
)
```

Both cases will throw a `TypeError` when the donation has a PaymentType that is not Paypal.

### Example 2 - Executing different code paths for different payment types
Before:
```
$payment = $donation->getPaymentMethod();
switch ( $payment ) {
    case PaymentType::CREDITCARD:
        do_cc_things($payment);
        break;
    case PaymentType::PAYPAL;
         do_ppl_things($payment);
         break;
}
```

After:
```
$dispatcher = new PaymentMethodDispatcher( [
    PaymentType::CREDITCARD => do_cc_things,
    PaymentType::PAYPAL => do_ppl_things,
] );
$dispatcher->dispatch( $donation->getPaymentMethod() );
```
This is for https://phabricator.wikimedia.org/T192323
