### PR TITLE
Move over Payment UCs from FF app

### DIFF
--- a/src/Domain/BankDataGenerator.php
+++ b/src/Domain/BankDataGenerator.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Domain;
+
+use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
+use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Christoph Fischer < christoph.fischer@wikimedia.de >
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+interface BankDataGenerator {
+
+	public function getBankDataFromAccountData( string $account, string $bankCode ): BankData;
+
+	public function getBankDataFromIban( Iban $iban ): BankData;
+
+}

--- a/src/Domain/IbanBlacklist.php
+++ b/src/Domain/IbanBlacklist.php
@@ -5,13 +5,12 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\PaymentContext\Domain;
 
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
-use WMDE\FunValidators\ValidationResult;
 
 /**
  * @licence GNU GPL v2+
  */
-interface IbanValidator extends IbanBlacklist {
+interface IbanBlacklist {
 
-	public function validate( Iban $value, string $fieldName = '' ): ValidationResult;
+	public function isIbanBlocked( Iban $iban ): bool;
 
 }

--- a/src/ResponseModel/IbanResponse.php
+++ b/src/ResponseModel/IbanResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\ResponseModel;
+
+use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class IbanResponse {
+
+	public static function newSuccessResponse( BankData $bankData ): self {
+		return new self( $bankData );
+	}
+
+	public static function newFailureResponse(): self {
+		return new self();
+	}
+
+	private $bankData;
+
+	private function __construct( BankData $bankData = null ) {
+		$this->bankData = $bankData;
+	}
+
+	public function isSuccessful(): bool {
+		return $this->bankData !== null;
+	}
+
+	public function getBankData(): BankData {
+		if ( $this->bankData === null ) {
+			throw new \RuntimeException( 'Cannot get the bank data of a failure response' );
+		}
+
+		return $this->bankData;
+	}
+
+}

--- a/src/UseCases/CheckIban/CheckIbanUseCase.php
+++ b/src/UseCases/CheckIban/CheckIbanUseCase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\UseCases\CheckIban;
+
+use WMDE\Fundraising\PaymentContext\Domain\BankDataGenerator;
+use WMDE\Fundraising\PaymentContext\Domain\IbanValidator;
+use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
+use WMDE\Fundraising\PaymentContext\ResponseModel\IbanResponse;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Kai Nissen <kai.nissen@wikimedia.de>
+ */
+class CheckIbanUseCase {
+
+	private $bankDataConverter;
+	private $ibanValidator;
+
+	public function __construct( BankDataGenerator $bankDataConverter, IbanValidator $ibanValidator ) {
+		$this->bankDataConverter = $bankDataConverter;
+		$this->ibanValidator = $ibanValidator;
+	}
+
+	public function checkIban( Iban $iban ): IbanResponse {
+		if ( !$this->ibanValidator->validate( $iban )->isSuccessful() ) {
+			return IbanResponse::newFailureResponse();
+		}
+
+		return IbanResponse::newSuccessResponse(
+			$this->bankDataConverter->getBankDataFromIban( $iban )
+		);
+	}
+
+}

--- a/src/UseCases/GenerateIban/GenerateIbanRequest.php
+++ b/src/UseCases/GenerateIban/GenerateIbanRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\UseCases\GenerateIban;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Kai Nissen <kai.nissen@wikimedia.de>
+ */
+class GenerateIbanRequest {
+
+	private $bankAccount;
+	private $bankCode;
+
+	public function __construct( string $bankAccount, string $bankCode ) {
+		$this->bankAccount = $bankAccount;
+		$this->bankCode = $bankCode;
+	}
+
+	public function getBankAccount(): string {
+		return $this->bankAccount;
+	}
+
+	public function getBankCode(): string {
+		return $this->bankCode;
+	}
+
+}

--- a/src/UseCases/GenerateIban/GenerateIbanUseCase.php
+++ b/src/UseCases/GenerateIban/GenerateIbanUseCase.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\UseCases\GenerateIban;
+
+use WMDE\Fundraising\PaymentContext\Domain\BankDataGenerator;
+use WMDE\Fundraising\PaymentContext\Domain\IbanBlacklist;
+use WMDE\Fundraising\PaymentContext\ResponseModel\IbanResponse;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Kai Nissen <kai.nissen@wikimedia.de>
+ */
+class GenerateIbanUseCase {
+
+	private $bankDataGenerator;
+	private $ibanBlacklist;
+
+	public function __construct( BankDataGenerator $bankDataGenerator, IbanBlacklist $ibanBlacklist ) {
+		$this->bankDataGenerator = $bankDataGenerator;
+		$this->ibanBlacklist = $ibanBlacklist;
+	}
+
+	public function generateIban( GenerateIbanRequest $request ): IbanResponse {
+		try {
+			$bankData = $this->bankDataGenerator->getBankDataFromAccountData(
+				$request->getBankAccount(),
+				$request->getBankCode()
+			);
+
+			if ( $this->ibanBlacklist->isIbanBlocked( $bankData->getIban() ) ) {
+				return IbanResponse::newFailureResponse();
+			}
+		}
+		catch ( \RuntimeException $ex ) {
+			return IbanResponse::newFailureResponse();
+		}
+
+		return IbanResponse::newSuccessResponse( $bankData );
+	}
+
+}

--- a/tests/Data/ValidBankData.php
+++ b/tests/Data/ValidBankData.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Data;
+
+use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
+use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ValidBankData extends BankData {
+
+	public const IBAN = 'DE00123456789012345678';
+	public const BIC = 'SCROUSDBXXX';
+	public const BANK_NAME = 'Scrooge Bank';
+	public const BANK_CODE = '12345678';
+	public const ACCOUNT = '1234567890';
+
+	public function __construct() {
+		$this->setIban( new Iban( self::IBAN ) )
+			->setBic( self::BIC )
+			->setBankName( self::BANK_NAME )
+			->setBankCode( self::BANK_CODE )
+			->setAccount( self::ACCOUNT );
+
+		$this->assertNoNullFields()->freeze();
+	}
+
+}

--- a/tests/Fixtures/FailingIbanBlacklist.php
+++ b/tests/Fixtures/FailingIbanBlacklist.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Fixtures;
+
+use WMDE\Fundraising\PaymentContext\Domain\IbanBlacklist;
+use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class FailingIbanBlacklist implements IbanBlacklist {
+
+	public function isIbanBlocked( Iban $iban ): bool {
+		return true;
+	}
+
+}

--- a/tests/Fixtures/SucceedingIbanBlacklist.php
+++ b/tests/Fixtures/SucceedingIbanBlacklist.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Fixtures;
+
+use WMDE\Fundraising\PaymentContext\Domain\IbanBlacklist;
+use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class SucceedingIbanBlacklist implements IbanBlacklist {
+
+	public function isIbanBlocked( Iban $iban ): bool {
+		return false;
+	}
+
+}

--- a/tests/Integration/UseCases/GenerateIban/GenerateIbanUseCaseTest.php
+++ b/tests/Integration/UseCases/GenerateIban/GenerateIbanUseCaseTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Integration\UseCases\GenerateIban;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\Domain\BankDataGenerator;
+use WMDE\Fundraising\PaymentContext\ResponseModel\IbanResponse;
+use WMDE\Fundraising\PaymentContext\Tests\Data\ValidBankData;
+use WMDE\Fundraising\PaymentContext\Tests\Fixtures\FailingIbanBlacklist;
+use WMDE\Fundraising\PaymentContext\Tests\Fixtures\SucceedingIbanBlacklist;
+use WMDE\Fundraising\PaymentContext\UseCases\GenerateIban\GenerateIbanRequest;
+use WMDE\Fundraising\PaymentContext\UseCases\GenerateIban\GenerateIbanUseCase;
+
+/**
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\GenerateIban\GenerateIbanUseCase
+ *
+ * @licence GNU GPL v2+
+ * @author Kai Nissen <kai.nissen@wikimedia.de>
+ */
+class GenerateIbanUseCaseTest extends TestCase {
+
+	private $bankDataGenerator;
+	private $ibanBlacklist;
+
+	public function setUp() {
+		$this->bankDataGenerator = $this->newSucceedingBankDataGenerator();
+		$this->ibanBlacklist = new SucceedingIbanBlacklist();
+	}
+
+	private function newSucceedingBankDataGenerator(): BankDataGenerator {
+		$generator = $this->createMock( BankDataGenerator::class );
+
+		$generator->method( $this->anything() )->willReturn( new ValidBankData() );
+
+		return $generator;
+	}
+
+	private function newGenerateIbanUseCase(): GenerateIbanUseCase {
+		return new GenerateIbanUseCase(
+			$this->bankDataGenerator,
+			$this->ibanBlacklist
+		);
+	}
+
+	public function testWhenValidBankAccountDataIsGiven_fullBankDataIsReturned(): void {
+		$this->bankDataGenerator = $this->createMock( BankDataGenerator::class );
+
+		$this->bankDataGenerator->expects( $this->once() )
+			->method( 'getBankDataFromAccountData' )
+			->with( $this->equalTo( '1015754243' ), $this->equalTo( '20050550' ) )
+			->willReturn( new ValidBankData() );
+
+		$useCase = $this->newGenerateIbanUseCase();
+
+		$this->assertEquals(
+			IbanResponse::newSuccessResponse( new ValidBankData() ),
+			$useCase->generateIban( new GenerateIbanRequest( '1015754243', '20050550' ) )
+		);
+	}
+
+	public function testWhenBankDataGeneratorThrowsException_failureResponseIsReturned(): void {
+		$this->bankDataGenerator = $this->createMock( BankDataGenerator::class );
+		$this->bankDataGenerator->method( $this->anything() )->willThrowException( new \RuntimeException() );
+
+		$useCase = $this->newGenerateIbanUseCase();
+
+		$this->assertEquals(
+			IbanResponse::newFailureResponse(),
+			$useCase->generateIban( new GenerateIbanRequest( '1015754241', '20050550' ) )
+		);
+	}
+
+	public function testWhenBlockedBankAccountDataIsGiven_failureResponseIsReturned(): void {
+		$this->ibanBlacklist = new FailingIbanBlacklist();
+
+		$useCase = $this->newGenerateIbanUseCase();
+
+		$this->assertEquals(
+			IbanResponse::newFailureResponse(),
+			$useCase->generateIban( new GenerateIbanRequest( '1194700', '10020500' ) )
+		);
+	}
+}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T188394

Production code unmodified except for splitting an IbanBlacklist interface
out of IbanValidator to be used in the UC test. That test was modified
to no longer use the real KontoCheck stuff.

I'm not entirely happy with the name IbanBlacklist as this is too specific. The service checks if the iban is allowed, with the blacklist being an implementation detail. Can't think of a good name. IbanAuthorizer maybe?