### PR TITLE
Simplify bank data validation

### DIFF
--- a/src/Domain/BankDataValidator.php
+++ b/src/Domain/BankDataValidator.php
@@ -28,7 +28,6 @@ class BankDataValidator {
 		$violations = [];
 
 		$violations[] = $this->getFieldViolation( $validator->validate( $bankData->getIban()->toString() ), 'iban' );
-		$violations[] = $this->getFieldViolation( $validator->validate( $bankData->getBic() ), 'bic' );
 
 		if ( $bankData->getIban()->getCountryCode() === 'DE' ) {
 			$stringLengthValidator = new StringLengthValidator();

--- a/src/Domain/BankDataValidator.php
+++ b/src/Domain/BankDataValidator.php
@@ -31,8 +31,6 @@ class BankDataValidator {
 
 		if ( $bankData->getIban()->getCountryCode() === 'DE' ) {
 			$stringLengthValidator = new StringLengthValidator();
-			$violations[] = $this->getFieldViolation( $validator->validate( $bankData->getAccount() ), 'konto' );
-			$violations[] = $this->getFieldViolation( $validator->validate( $bankData->getBankCode() ), 'blz' );
 			$violations[] = $this->getFieldViolation(
 				$stringLengthValidator->validate( $bankData->getAccount(), 10 ),
 				'konto'

--- a/src/Domain/BankDataValidator.php
+++ b/src/Domain/BankDataValidator.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain;
 
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
 use WMDE\FunValidators\CanValidateField;
+use WMDE\FunValidators\ConstraintViolation;
 use WMDE\FunValidators\ValidationResult;
 use WMDE\FunValidators\Validators\RequiredFieldValidator;
 use WMDE\FunValidators\Validators\StringLengthValidator;
@@ -17,6 +18,12 @@ use WMDE\FunValidators\Validators\StringLengthValidator;
 class BankDataValidator {
 	use CanValidateField;
 
+	public const INVALID_BIC = 'invalid_bic';
+
+	private const BIC_MAXLEN = 11;
+	private const BANK_ACCOUNT_MAXLEN = 10;
+	private const BANK_CODE_MAXLEN = 8;
+
 	private $ibanValidator;
 
 	public function __construct( IbanValidator $ibanValidator ) {
@@ -24,19 +31,23 @@ class BankDataValidator {
 	}
 
 	public function validate( BankData $bankData ): ValidationResult {
-		$validator = new RequiredFieldValidator();
+		$requiredValidator = new RequiredFieldValidator();
+		$stringLengthValidator = new StringLengthValidator();
 		$violations = [];
 
-		$violations[] = $this->getFieldViolation( $validator->validate( $bankData->getIban()->toString() ), 'iban' );
+		$violations[] = $this->getFieldViolation(
+			$requiredValidator->validate( $bankData->getIban()->toString() ),
+			'iban'
+		);
+		$violations[] = $this->validateBic( $bankData->getBic() );
 
 		if ( $bankData->getIban()->getCountryCode() === 'DE' ) {
-			$stringLengthValidator = new StringLengthValidator();
 			$violations[] = $this->getFieldViolation(
-				$stringLengthValidator->validate( $bankData->getAccount(), 10 ),
+				$stringLengthValidator->validate( $bankData->getAccount(), self::BANK_ACCOUNT_MAXLEN ),
 				'konto'
 			);
 			$violations[] = $this->getFieldViolation(
-				$stringLengthValidator->validate( $bankData->getBankCode(), 8 ),
+				$stringLengthValidator->validate( $bankData->getBankCode(), self::BANK_CODE_MAXLEN ),
 				'blz'
 			);
 		}
@@ -44,6 +55,14 @@ class BankDataValidator {
 		$violations[] = $this->getFieldViolation( $this->ibanValidator->validate( $bankData->getIban() ), 'iban' );
 
 		return new ValidationResult( ...array_filter( $violations ) );
+	}
+
+	private function validateBic( string $bic ): ?ConstraintViolation {
+		// see https://en.wikipedia.org/wiki/ISO_9362
+		if ( $bic === '' || preg_match( '/^[A-Z]{6}[2-9A-Z][0-9A-NP-Z](XXX|[0-9A-WYZ][0-9A-Z]{2})?$/', $bic ) ) {
+			return null;
+		}
+		return new ConstraintViolation( $bic, self::INVALID_BIC, 'bic' );
 	}
 
 }

--- a/tests/Unit/Domain/BankDataValidatorTest.php
+++ b/tests/Unit/Domain/BankDataValidatorTest.php
@@ -32,13 +32,6 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 	public function invalidBankDataProvider(): array {
 		return [
 			[
-				'DB00123456789012345678',
-				'',
-				'',
-				'',
-				'',
-			],
-			[
 				'',
 				'SCROUSDBXXX',
 				'',
@@ -77,6 +70,13 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 
 	public function validBankDataProvider(): array {
 		return [
+			[
+				'DB00123456789012345678',
+				'',
+				'',
+				'',
+				'',
+			],
 			[
 				'DB00123456789012345678',
 				'SCROUSDBXXX',

--- a/tests/Unit/Domain/BankDataValidatorTest.php
+++ b/tests/Unit/Domain/BankDataValidatorTest.php
@@ -64,6 +64,22 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 				'000000000012345678',
 				'Old-Style bank data must not be too long',
 			],
+			[
+				'DE00123456789012345678',
+				' BCEELULL ',
+				'',
+				'',
+				'',
+				'BIC must not contain spaces',
+			],
+			[
+				'DE00123456789012345678',
+				'No BIC',
+				'Scrooge Bank',
+				'',
+				'',
+				'BIC must be well-formed',
+			],
 		];
 	}
 
@@ -99,6 +115,30 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 				'',
 				'',
 				'Single IBAN is valid',
+			],
+			[
+				'DB00123456789012345678',
+				'RZTIAT22263',
+				'',
+				'',
+				'',
+				'Long BIC is valid',
+			],
+			[
+				'DB00123456789012345678',
+				'BCEELULL',
+				'',
+				'',
+				'',
+				'Short BIC is valid',
+			],
+			[
+				'DB00123456789012345678',
+				'BELADEBEXXX',
+				'',
+				'',
+				'',
+				'BIC with XXX branch name is valid',
 			],
 			[
 				'DB00123456789012345678',

--- a/tests/Unit/Domain/BankDataValidatorTest.php
+++ b/tests/Unit/Domain/BankDataValidatorTest.php
@@ -8,6 +8,7 @@ use WMDE\Fundraising\PaymentContext\Domain\BankDataValidator;
 use WMDE\Fundraising\PaymentContext\Domain\IbanValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
+use WMDE\FunValidators\ConstraintViolation;
 use WMDE\FunValidators\ValidationResult;
 
 /**
@@ -22,11 +23,11 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider invalidBankDataProvider
 	 */
 	public function testFieldsMissing_validationFails( string $iban, string $bic, string $bankName,
-		string $bankCode, string $account ): void {
+		string $bankCode, string $account, string $message ): void {
 
 		$bankDataValidator = $this->newBankDataValidator();
 		$bankData = $this->newBankData( $iban, $bic, $bankName, $bankCode, $account );
-		$this->assertFalse( $bankDataValidator->validate( $bankData )->isSuccessful() );
+		$this->assertFalse( $bankDataValidator->validate( $bankData )->isSuccessful(), $message );
 	}
 
 	public function invalidBankDataProvider(): array {
@@ -37,6 +38,7 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 				'',
 				'',
 				'',
+				'BIC is not sufficient',
 			],
 			[
 				'',
@@ -44,28 +46,48 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 				'Scrooge Bank',
 				'',
 				'',
+				'Bank name is not sufficient',
 			],
-			# validation fails for German IBAN and missing obsolete account data
+			[
+				'',
+				'',
+				'Scrooge Bank',
+				'124567',
+				'12345678',
+				'Old-Style bank data is not sufficient',
+			],
 			[
 				'DE00123456789012345678',
 				'SCROUSDBXXX',
 				'Scrooge Bank',
-				'',
-				'',
+				'0000000000124567',
+				'000000000012345678',
+				'Old-Style bank data must not be too long',
 			],
 		];
 	}
 
-	public function testAllRequiredFieldsGiven_validationSucceeds(): void {
+	public function testGivenFailingIbanValidator_validationFails() {
+		$failingIbanValidator = $this->getMockBuilder( IbanValidator::class )->disableOriginalConstructor()->getMock();
+		$failingIbanValidator->method( 'validate' )
+			->willReturn( new ValidationResult( new ConstraintViolation( '', 'IBAN smells funny' ) ) );
+		$bankData = $this->newBankData( 'DE00123456789012345678', 'SCROUSDBXXX', 'Scrooge Bank',
+			'12345678', '1234567890' );
+		$validator = new BankDataValidator( $failingIbanValidator );
+
+		$this->assertFalse( $validator->validate( $bankData )->isSuccessful() );
+	}
+
+	/**
+	 * @dataProvider validBankDataProvider
+	 */
+	public function testAllRequiredFieldsGiven_validationSucceeds( string $iban, string $bic, string $bankName,
+		string $bankCode, string $account, string $message ): void {
+
+		$bankData = $this->newBankData( $iban, $bic, $bankName, $bankCode, $account );
 		$bankDataValidator = $this->newBankDataValidator();
-		$bankData = $this->newBankData(
-			'DE00123456789012345678',
-			'SCROUSDBXXX',
-			'Scrooge Bank',
-			'12345678',
-			'1234567890'
-		);
-		$this->assertTrue( $bankDataValidator->validate( $bankData )->isSuccessful() );
+
+		$this->assertTrue( $bankDataValidator->validate( $bankData )->isSuccessful(), $message );
 	}
 
 	public function validBankDataProvider(): array {
@@ -76,6 +98,7 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 				'',
 				'',
 				'',
+				'Single IBAN is valid',
 			],
 			[
 				'DB00123456789012345678',
@@ -83,6 +106,7 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 				'Scrooge Bank',
 				'',
 				'',
+				'IBAN, BIC and Bank name are valid',
 			],
 			[
 				'DE00123456789012345678',
@@ -90,6 +114,7 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 				'Scrooge Bank',
 				'12345678',
 				'1234567890',
+				'Full set of payment data is valid',
 			],
 		];
 	}
@@ -100,7 +125,8 @@ class BankDataValidatorTest extends \PHPUnit\Framework\TestCase {
 			->setBic( $bic )
 			->setBankName( $bankName )
 			->setBankCode( $bankCode )
-			->setAccount( $account );
+			->setAccount( $account )
+			->freeze();
 	}
 
 	private function newBankDataValidator(): BankDataValidator {


### PR DESCRIPTION
Remove BIC and old-style bank data as a required fields.

Add test cases.

This is for https://phabricator.wikimedia.org/T192921
