### PR TITLE
Add getter for child payments

### DIFF
--- a/src/Domain/Model/PayPalData.php
+++ b/src/Domain/Model/PayPalData.php
@@ -211,4 +211,8 @@ class PayPalData {
 		return $this->childPayments[$paymentId];
 	}
 
+	public function getAllChildPayments(): array {
+		return $this->childPayments;
+	}
+
 }


### PR DESCRIPTION
This getter is needed to store the child payment information in the
donation BLOB field. This helps developing a short-tem fix for
https://phabricator.wikimedia.org/T239644

Ideally, as tracked in https://phabricator.wikimedia.org/T192323, the
Payment domain keeps track of child payments itself so the other domains
don't need to.