### PR TITLE
Revert "Change Notification request data type"

### DIFF
--- a/src/RequestModel/PayPalPaymentNotificationRequest.php
+++ b/src/RequestModel/PayPalPaymentNotificationRequest.php
@@ -211,11 +211,11 @@ class PayPalPaymentNotificationRequest {
 		return $this;
 	}
 
-	public function getPaymentTimestamp(): \DateTimeImmutable {
+	public function getPaymentTimestamp(): string {
 		return $this->paymentTimestamp;
 	}
 
-	public function setPaymentTimestamp( \DateTimeImmutable $paymentTimestamp ): self {
+	public function setPaymentTimestamp( string $paymentTimestamp ): self {
 		$this->paymentTimestamp = $paymentTimestamp;
 		return $this;
 	}


### PR DESCRIPTION
Changing the type to DateTimeImmutable but not PayPalData is
inconsistent. The changes necessary in donations,
memberships and FundraisingFrontend should be done in one fell swoop,
and not piece-by-piece.

This reverts commit eae1c5d2fb003b069e38cc8445d8ecbfc91d610d.