### PR TITLE
Add real paymentCompleted checks on PP and CC

### DIFF
--- a/src/Domain/Model/CreditCardPayment.php
+++ b/src/Domain/Model/CreditCardPayment.php
@@ -39,6 +39,6 @@ class CreditCardPayment implements PaymentMethod {
 	}
 
 	public function paymentCompleted(): bool {
-		return $this->creditCardData !== null;
+		return $this->creditCardData !== null && $this->creditCardData->getTransactionId() !== '';
 	}
 }

--- a/src/Domain/Model/PayPalPayment.php
+++ b/src/Domain/Model/PayPalPayment.php
@@ -37,6 +37,6 @@ class PayPalPayment implements PaymentMethod {
 	}
 
 	public function paymentCompleted(): bool {
-		return $this->payPalData !== null;
+		return $this->payPalData->getPayerId() !== '';
 	}
 }

--- a/tests/Unit/Domain/Model/CreditCardPaymentTest.php
+++ b/tests/Unit/Domain/Model/CreditCardPaymentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardTransactionData;
+
+/**
+ * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment
+ */
+class CreditCardPaymentTest extends TestCase {
+
+	public function testGivenNullCreditCardTransactionData_isUncompleted(): void {
+		$creditCardPayment = new CreditCardPayment();
+		$this->assertFalse( $creditCardPayment->paymentCompleted() );
+	}
+
+	public function testGivenCreditCardTransactionDataWithNoTransactionID_isUncompleted(): void {
+		$creditCardPayment = new CreditCardPayment( new CreditCardTransactionData() );
+		$this->assertFalse( $creditCardPayment->paymentCompleted() );
+	}
+
+	public function testGivenCreditCardTransactionDataWithTransactionID_isCompleted(): void {
+		$creditCardPayment = new CreditCardPayment( ( new CreditCardTransactionData() )->setTransactionId( 42 ) );
+		$this->assertTrue( $creditCardPayment->paymentCompleted() );
+	}
+}

--- a/tests/Unit/Domain/Model/PayPalPaymentTest.php
+++ b/tests/Unit/Domain/Model/PayPalPaymentTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalData;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
+
+/**
+ * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment
+ */
+class PayPalPaymentTest extends TestCase {
+
+	public function testGivenPaypalDataWithNoPayerID_isUncompleted(): void {
+		$payPalPayment = new PayPalPayment( new PayPalData() );
+		$this->assertFalse( $payPalPayment->paymentCompleted() );
+	}
+
+	public function testGivenPaypalDataWithPayerID_isCompleted(): void {
+		$payPalPayment = new PayPalPayment( ( new PayPalData() )->setPayerId( 42 ) );
+		$this->assertTrue( $payPalPayment->paymentCompleted() );
+	}
+}

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -36,4 +36,15 @@ class SofortPaymentTest extends TestCase {
 		$sofortPayment->setConfirmedAt( new DateTime( 'now' ) );
 		$this->assertTrue( $sofortPayment->isConfirmedPayment() );
 	}
+
+	public function testPaymentWithoutDate_isUncompleted(): void {
+		$sofortPayment = new SofortPayment( 'ipsum' );
+		$this->assertFalse( $sofortPayment->paymentCompleted() );
+	}
+
+	public function testPaymentWithDate_isCompleted(): void {
+		$sofortPayment = new SofortPayment( 'ipsum' );
+		$sofortPayment->setConfirmedAt( new DateTime( 'now' ) );
+		$this->assertTrue( $sofortPayment->paymentCompleted() );
+	}
 }


### PR DESCRIPTION
Follow up for https://github.com/wmde/fundraising-payments/pull/34 that adds real actual working checks for if the payment has been completed on PayPal and Credit Card payments.