### PR TITLE
Add new BookablePayment interface

### DIFF
--- a/src/Domain/Model/BankTransferPayment.php
+++ b/src/Domain/Model/BankTransferPayment.php
@@ -12,7 +12,7 @@ use DateTimeImmutable;
  */
 class BankTransferPayment implements PaymentMethod {
 
-	private $bankTransferCode;
+	private string $bankTransferCode;
 
 	public function __construct( string $bankTransferCode ) {
 		$this->bankTransferCode = $bankTransferCode;

--- a/src/Domain/Model/BookablePayment.php
+++ b/src/Domain/Model/BookablePayment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WMDE\Fundraising\PaymentContext\Domain\Model;
+
+use DomainException;
+use InvalidArgumentException;
+
+interface BookablePayment {
+	/**
+	 * Mark payment as booked
+	 *
+	 * Implementations MUST check if $transactionData has the right type.
+	 *
+	 * @param PaymentTransactionData $transactionData
+	 *
+	 * @throws DomainException If payment can't be booked (e.g. because it's already booked)
+	 * @throws InvalidArgumentException If $transactionData class does not match needed payment type
+	 */
+	public function bookPayment( PaymentTransactionData $transactionData ): void;
+}

--- a/src/Domain/Model/CreditCardTransactionData.php
+++ b/src/Domain/Model/CreditCardTransactionData.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\PaymentContext\Infrastructure\CreditCardExpiry;
  * @license GPL-2.0-or-later
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class CreditCardTransactionData {
+class CreditCardTransactionData implements PaymentTransactionData {
 	use FreezableValueObject;
 
 	private $transactionId = '';

--- a/src/Domain/Model/DirectDebitPayment.php
+++ b/src/Domain/Model/DirectDebitPayment.php
@@ -12,7 +12,7 @@ use DateTimeImmutable;
  */
 class DirectDebitPayment implements PaymentMethod {
 
-	private $bankData;
+	private BankData $bankData;
 
 	public function __construct( BankData $bankData ) {
 		$this->bankData = $bankData;

--- a/src/Domain/Model/PayPalData.php
+++ b/src/Domain/Model/PayPalData.php
@@ -11,7 +11,7 @@ use WMDE\FreezableValueObject\FreezableValueObject;
  * @license GPL-2.0-or-later
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class PayPalData {
+class PayPalData implements PaymentTransactionData {
 	use FreezableValueObject;
 
 	private $payerId = '';

--- a/src/Domain/Model/PayPalPayment.php
+++ b/src/Domain/Model/PayPalPayment.php
@@ -4,13 +4,17 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\PaymentContext\Domain\Model;
 
+use DateTimeImmutable;
+use DomainException;
+use InvalidArgumentException;
+
 /**
  * @license GPL-2.0-or-later
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class PayPalPayment implements PaymentMethod {
+class PayPalPayment implements PaymentMethod, BookablePayment {
 
-	private $payPalData;
+	private PayPalData $payPalData;
 
 	public function __construct( PayPalData $payPalData ) {
 		$this->payPalData = $payPalData;
@@ -24,6 +28,10 @@ class PayPalPayment implements PaymentMethod {
 		return $this->payPalData;
 	}
 
+	/**
+	 * @param PayPalData $palPayData
+	 * @deprecated use bookPayment instead
+	 */
 	public function addPayPalData( PayPalData $palPayData ): void {
 		$this->payPalData = $palPayData;
 	}
@@ -32,11 +40,25 @@ class PayPalPayment implements PaymentMethod {
 		return true;
 	}
 
-	public function getValuationDate(): \DateTimeImmutable {
-		return new \DateTimeImmutable( $this->payPalData->getPaymentTimestamp() );
+	public function getValuationDate(): DateTimeImmutable {
+		return new DateTimeImmutable( $this->payPalData->getPaymentTimestamp() );
 	}
 
 	public function paymentCompleted(): bool {
 		return $this->payPalData->getPayerId() !== '';
 	}
+
+	public function bookPayment( PaymentTransactionData $transactionData ): void {
+		if ( !( $transactionData instanceof PayPalData ) ) {
+			throw new InvalidArgumentException( sprintf( 'Illegal transaction data class for paypal: %s', get_class( $transactionData ) ) );
+		}
+		if ( $transactionData->getPayerId() === '' ) {
+			throw new InvalidArgumentException( 'Transaction data must have payer ID' );
+		}
+		if ( $this->paymentCompleted() ) {
+			throw new DomainException( 'Payment is already completed' );
+		}
+		$this->payPalData = $transactionData;
+	}
+
 }

--- a/src/Domain/Model/PaymentTransactionData.php
+++ b/src/Domain/Model/PaymentTransactionData.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WMDE\Fundraising\PaymentContext\Domain\Model;
+
+/**
+ * This is a marker interface that all value objects for payments that have transaction data used in BookablePayment
+ */
+interface PaymentTransactionData {
+
+}

--- a/src/Domain/Model/PaymentWithoutAssociatedData.php
+++ b/src/Domain/Model/PaymentWithoutAssociatedData.php
@@ -12,7 +12,7 @@ use DateTimeImmutable;
  */
 class PaymentWithoutAssociatedData implements PaymentMethod {
 
-	private $paymentMethod;
+	private string $paymentMethod;
 
 	public function __construct( string $paymentMethodId ) {
 		$this->paymentMethod = $paymentMethodId;

--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -6,20 +6,22 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
 
 use DateTime;
 use DateTimeImmutable;
+use DomainException;
+use InvalidArgumentException;
 
-class SofortPayment implements PaymentMethod {
+class SofortPayment implements PaymentMethod, BookablePayment {
+
+	private string $bankTransferCode = '';
 
 	/**
-	 * @var string
+	 * This is mutable by accident and should be immutable, see https://phabricator.wikimedia.org/T281895
+	 * @var null|DateTime
 	 */
-	private $bankTransferCode = '';
-	/**
-	 * @var DateTime|null
-	 */
-	private $confirmedAt;
+	private ?DateTime $confirmedAt;
 
 	public function __construct( string $bankTransferCode ) {
 		$this->bankTransferCode = $bankTransferCode;
+		$this->confirmedAt = null;
 	}
 
 	public function getId(): string {
@@ -34,6 +36,10 @@ class SofortPayment implements PaymentMethod {
 		return $this->confirmedAt;
 	}
 
+	/**
+	 * @param DateTime|null $confirmedAt
+	 * @deprecated Use bookPayment() instead
+	 */
 	public function setConfirmedAt( ?DateTime $confirmedAt ): void {
 		$this->confirmedAt = $confirmedAt;
 	}
@@ -56,4 +62,15 @@ class SofortPayment implements PaymentMethod {
 	public function paymentCompleted(): bool {
 		return $this->getConfirmedAt() !== null;
 	}
+
+	public function bookPayment( PaymentTransactionData $transactionData ): void {
+		if ( !( $transactionData instanceof SofortTransactionData ) ) {
+			throw new InvalidArgumentException( sprintf( 'Illegal transaction data class for Sofort payment: %s', get_class( $transactionData ) ) );
+		}
+		if ( $this->paymentCompleted() ) {
+			throw new DomainException( 'Payment is already completed' );
+		}
+		$this->confirmedAt = DateTime::createFromImmutable( $transactionData->getValuationDate() );
+	}
+
 }

--- a/src/Domain/Model/SofortTransactionData.php
+++ b/src/Domain/Model/SofortTransactionData.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Domain\Model;
+
+use DateTimeImmutable;
+
+class SofortTransactionData implements PaymentTransactionData {
+	private DateTimeImmutable $valuationDate;
+
+	public function __construct( DateTimeImmutable $valuationDate ) {
+		$this->valuationDate = $valuationDate;
+	}
+
+	public function getValuationDate(): DateTimeImmutable {
+		return $this->valuationDate;
+	}
+
+}

--- a/tests/Unit/Domain/Model/CreditCardPaymentTest.php
+++ b/tests/Unit/Domain/Model/CreditCardPaymentTest.php
@@ -7,13 +7,15 @@ namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
 use PHPUnit\Framework\TestCase;
 use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardTransactionData;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentTransactionData;
 
 /**
  * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment
  */
 class CreditCardPaymentTest extends TestCase {
 
-	private const TRANSACTION_ID = '42';
+	private const TRANSACTION_ID = '7788998877';
+	private const OTHER_TRANSACTION_ID = '3388998877';
 
 	public function testGivenNullCreditCardTransactionData_isUncompleted(): void {
 		$creditCardPayment = new CreditCardPayment();
@@ -28,5 +30,46 @@ class CreditCardPaymentTest extends TestCase {
 	public function testGivenCreditCardTransactionDataWithTransactionID_isCompleted(): void {
 		$creditCardPayment = new CreditCardPayment( ( new CreditCardTransactionData() )->setTransactionId( self::TRANSACTION_ID ) );
 		$this->assertTrue( $creditCardPayment->paymentCompleted() );
+	}
+
+	public function testCompletePaymentWithInvalidTransactionObjectFails(): void {
+		$creditCardPayment = new CreditCardPayment( new CreditCardTransactionData() );
+		$wrongPaymentTransaction = new class() implements PaymentTransactionData {
+		};
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$creditCardPayment->bookPayment( $wrongPaymentTransaction );
+	}
+
+	public function testCompletePaymentWithEmptyTransactionDataFails(): void {
+		$creditCardPayment = new CreditCardPayment( new CreditCardTransactionData() );
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$creditCardPayment->bookPayment( new CreditCardTransactionData() );
+	}
+
+	public function testGivenCompletedPayment_completePaymentFails(): void {
+		$transactionData = new CreditCardTransactionData();
+		$transactionData->setTransactionId( self::TRANSACTION_ID );
+		$creditCardPayment = new CreditCardPayment( $transactionData );
+		$newTransactionData = new CreditCardTransactionData();
+		$newTransactionData->setTransactionId( self::OTHER_TRANSACTION_ID );
+
+		$this->expectException( \DomainException::class );
+
+		$creditCardPayment->bookPayment( $newTransactionData );
+	}
+
+	public function testCompletePaymentWithValidTransactionDataSucceeds(): void {
+		$creditCardPayment = new CreditCardPayment( new CreditCardTransactionData() );
+		$transactionData = new CreditCardTransactionData();
+		$transactionData->setTransactionId( self::TRANSACTION_ID );
+
+		$creditCardPayment->bookPayment( $transactionData );
+
+		$this->assertTrue( $creditCardPayment->paymentCompleted() );
+		$this->assertSame( self::TRANSACTION_ID, $creditCardPayment->getCreditCardData()->getTransactionId() );
 	}
 }

--- a/tests/Unit/Domain/Model/PayPalPaymentTest.php
+++ b/tests/Unit/Domain/Model/PayPalPaymentTest.php
@@ -4,6 +4,9 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardTransactionData;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentTransactionData;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalData;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
 
@@ -13,6 +16,7 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
 class PayPalPaymentTest extends TestCase {
 
 	private const PAYER_ID = '42';
+	private const OTHER_PAYER_ID = '23';
 
 	public function testGivenPaypalDataWithNoPayerID_isUncompleted(): void {
 		$payPalPayment = new PayPalPayment( new PayPalData() );
@@ -22,5 +26,46 @@ class PayPalPaymentTest extends TestCase {
 	public function testGivenPaypalDataWithPayerID_isCompleted(): void {
 		$payPalPayment = new PayPalPayment( ( new PayPalData() )->setPayerId( self::PAYER_ID ) );
 		$this->assertTrue( $payPalPayment->paymentCompleted() );
+	}
+
+	public function testCompletePaymentWithInvalidTransactionObjectFails(): void {
+		$payment = new PayPalPayment( new PayPalData() );
+		$wrongPaymentTransaction = new class() implements PaymentTransactionData {
+		};
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$payment->bookPayment( $wrongPaymentTransaction );
+	}
+
+	public function testCompletePaymentWithEmptyPayerId(): void {
+		$payment = new PayPalPayment( new PayPalData() );
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$payment->bookPayment( new PayPalData() );
+	}
+
+	public function testGivenCompletedPayment_completePaymentFails(): void {
+		$transactionData = new PayPalData();
+		$transactionData->setPayerId( self::PAYER_ID );
+		$payment = new PayPalPayment( $transactionData );
+		$newTransactionData = new PayPalData();
+		$newTransactionData->setPayerId( self::OTHER_PAYER_ID );
+
+		$this->expectException( \DomainException::class );
+
+		$payment->bookPayment( $newTransactionData );
+	}
+
+	public function testCompletePaymentWithValidTransactionDataSucceeds(): void {
+		$payment = new PayPalPayment( new PayPalData() );
+		$newTransactionData = new PayPalData();
+		$newTransactionData->setPayerId( self::PAYER_ID );
+
+		$payment->bookPayment( $newTransactionData );
+
+		$this->assertTrue( $payment->paymentCompleted() );
+		$this->assertSame( self::PAYER_ID, $payment->getPayPalData()->getPayerId() );
 	}
 }


### PR DESCRIPTION
The new interface marks payments as bookable and enables sending
different transaction data through the same method. It complements the
`paymentComplete` method.

The new interface will enable Donations to implement a unified
`bookDonation` method that both changes the internal state of the
donation and the payment, instead of having two discrete, independent
steps of booking the donation and then adding the payment data.

We can also use the interface in memberships if needed.

This is a step towards implementing a richer payment domain (see https://phabricator.wikimedia.org/T192323)

Added typehints to some classes.