### PR TITLE
Use PHPStan on Level 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ fix-cs:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpcbf
 
 stan:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpstan analyse --level=1 --no-progress src/ tests/
+	docker-compose run --rm --no-deps app ./vendor/bin/phpstan analyse --level=5 --no-progress src/ tests/
 
 setup: install-php
 

--- a/src/Domain/PaymentUrlGenerator/PayPalConfig.php
+++ b/src/Domain/PaymentUrlGenerator/PayPalConfig.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator;
 
+use RuntimeException;
+
 /**
  * @license GPL-2.0-or-later
  * @author Kai Nissen < kai.nissen@wikimedia.de >
@@ -17,12 +19,12 @@ class PayPalConfig {
 	public const CONFIG_KEY_CANCEL_URL = 'cancel-url';
 	public const CONFIG_KEY_DELAY_IN_DAYS = 'delay-in-days';
 
-	private $payPalAccountAddress;
-	private $payPalBaseUrl;
-	private $notifyUrl;
-	private $returnUrl;
-	private $cancelUrl;
-	private $delayInDays;
+	private string $payPalAccountAddress;
+	private string $payPalBaseUrl;
+	private string $notifyUrl;
+	private string $returnUrl;
+	private string $cancelUrl;
+	private int $delayInDays;
 
 	private function __construct( string $payPalAccountAddress, string $payPalBaseUrl, string $notifyUrl,
 		string $returnUrl, string $cancelUrl, int $delayInDays ) {
@@ -35,10 +37,10 @@ class PayPalConfig {
 	}
 
 	/**
-	 * @param string[] $config
+	 * @param array{ 'account-address': string, 'base-url': string, 'notify-url': string, 'return-url': string, 'cancel-url': string, 'delay-in-days'?: int } $config
 	 *
 	 * @return PayPalConfig
-	 * @throws \RuntimeException
+	 * @throws RuntimeException
 	 */
 	public static function newFromConfig( array $config ): self {
 		return ( new self(
@@ -54,7 +56,7 @@ class PayPalConfig {
 	private function assertNoEmptyFields(): self {
 		foreach ( get_object_vars( $this ) as $fieldName => $fieldValue ) {
 			if ( empty( $fieldValue ) ) {
-				throw new \RuntimeException( "Configuration variable '$fieldName' can not be empty" );
+				throw new RuntimeException( "Configuration variable '$fieldName' can not be empty" );
 			}
 		}
 

--- a/tests/Unit/Domain/Model/CreditCardPaymentTest.php
+++ b/tests/Unit/Domain/Model/CreditCardPaymentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
@@ -10,6 +12,8 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardTransactionData;
  * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment
  */
 class CreditCardPaymentTest extends TestCase {
+
+	private const TRANSACTION_ID = '42';
 
 	public function testGivenNullCreditCardTransactionData_isUncompleted(): void {
 		$creditCardPayment = new CreditCardPayment();
@@ -22,7 +26,7 @@ class CreditCardPaymentTest extends TestCase {
 	}
 
 	public function testGivenCreditCardTransactionDataWithTransactionID_isCompleted(): void {
-		$creditCardPayment = new CreditCardPayment( ( new CreditCardTransactionData() )->setTransactionId( 42 ) );
+		$creditCardPayment = new CreditCardPayment( ( new CreditCardTransactionData() )->setTransactionId( self::TRANSACTION_ID ) );
 		$this->assertTrue( $creditCardPayment->paymentCompleted() );
 	}
 }

--- a/tests/Unit/Domain/Model/PayPalPaymentTest.php
+++ b/tests/Unit/Domain/Model/PayPalPaymentTest.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
 
@@ -11,13 +12,15 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
  */
 class PayPalPaymentTest extends TestCase {
 
+	private const PAYER_ID = '42';
+
 	public function testGivenPaypalDataWithNoPayerID_isUncompleted(): void {
 		$payPalPayment = new PayPalPayment( new PayPalData() );
 		$this->assertFalse( $payPalPayment->paymentCompleted() );
 	}
 
 	public function testGivenPaypalDataWithPayerID_isCompleted(): void {
-		$payPalPayment = new PayPalPayment( ( new PayPalData() )->setPayerId( 42 ) );
+		$payPalPayment = new PayPalPayment( ( new PayPalData() )->setPayerId( self::PAYER_ID ) );
 		$this->assertTrue( $payPalPayment->paymentCompleted() );
 	}
 }


### PR DESCRIPTION
Adapted 2 tests and 2 doc block to make PHPStan pass on level 5.
For Level 6 we'd need type hints on all class properties and arrays.