### PR TITLE
Improve composer install in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 install:
-  - travis_retry composer install --prefer-dist --no-interaction --ignore-platform-reqs
+  - travis_retry composer install --prefer-dist --no-interaction
 
 script:
   - make ci


### PR DESCRIPTION
Don't ignore platform requirements on composer install to avoid
installing incompatible versions.
