### PR TITLE
Increase level for 2nd run of PHPStan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 script:
   - make ci
   - make install-php COMPOSER_FLAGS="--no-dev -q" # Remove dev dependencies to make sure PHPStan creates errors if prod code depends on dev classes
-  - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan analyse --level 1 --no-progress src/ # Can't use "make stan" because stan was removed
+  - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan analyse --level 5 --no-progress src/ # Can't use "make stan" because stan was removed
 
 after_success:
   - vendor/bin/phpunit --coverage-clover coverage.clover


### PR DESCRIPTION
In CI, we run PHPStan a second time to check if we're depending on test
code. The check level should match the check level for the first run.
