### PR TITLE
Generate coverage report in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.phar
 composer.lock
 
 vendor/
+coverage/
 
 .phpunit.result.cache
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -29,4 +29,4 @@ build:
 
 build_failure_conditions:
     - 'project.metric_change("scrutinizer.test_coverage", < 0)'
-    - 'project.metric_change("scrutinizer.quality", < 1.0)'
+    - 'project.metric_change("scrutinizer.quality", < 0.0)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,11 @@ install:
   - travis_retry composer install --prefer-dist --no-interaction
 
 script:
-  - make ci
+  - make ci-with-coverage COVERAGE_FLAGS="--coverage-clover coverage.clover"
   - make install-php COMPOSER_FLAGS="--no-dev -q" # Remove dev dependencies to make sure PHPStan creates errors if prod code depends on dev classes
   - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan analyse --level 5 --no-progress src/ # Can't use "make stan" because stan was removed
 
 after_success:
-  - vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ current_group := $(shell id -g)
 BUILD_DIR     := $(PWD)
 DOCKER_FLAGS  := --interactive --tty
 DOCKER_IMAGE  := registry.gitlab.com/fun-tech/fundraising-frontend-docker
+COVERAGE_FLAGS := --coverage-html coverage
 
 install-php:
 	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) $(DOCKER_IMAGE):composer composer install $(COMPOSER_FLAGS)
@@ -12,10 +13,15 @@ update-php:
 
 ci: phpunit cs stan
 
+ci-with-coverage: phpunit-with-coverage cs stan
+
 test: phpunit
 
 phpunit:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpunit
+
+phpunit-with-coverage:
+	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm --no-deps -e XDEBUG_MODE=coverage app_debug ./vendor/bin/phpunit $(COVERAGE_FLAGS)
 
 cs:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpcs
@@ -28,4 +34,4 @@ stan:
 
 setup: install-php
 
-.PHONY: install-php update-php ci test phpunit cs fix-cs stan setup
+.PHONY: install-php update-php ci ci-with-coverage test phpunit phpunit-with-coverage cs fix-cs stan setup

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,11 @@
+version: '3.4'
+
+services:
+  app_debug:
+    image: "registry.gitlab.com/fun-tech/fundraising-frontend-docker:xdebug"
+    environment:
+      - XDEBUG_CONFIG=remote_host=${LOCAL_IP}
+      - PHP_IDE_CONFIG=serverName=donation.spenden.wikimedia.de
+    volumes:
+      - ./:/usr/src/app
+    working_dir: /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.4'
 
 services:
   app:


### PR DESCRIPTION
https://phabricator.wikimedia.org/T284180

Our old travis file tried to run PHPUnit after is was uninstalled,
leading to a missing coverage report file.

This change add coverage report output flags to the Makefile to
generate HTML by default and Clover XML when run through Travis.