### PR TITLE
Fix naming of sofort client implementation

### DIFF
--- a/src/DataAccess/Sofort/Transfer/SofortLibClient.php
+++ b/src/DataAccess/Sofort/Transfer/SofortLibClient.php
@@ -10,7 +10,7 @@ use Sofort\SofortLib\Sofortueberweisung;
 /**
  * Facade in front of Sofortueberweisung, an API to generate URLs of Sofort's checkout process
  */
-class SofortLibSofortClient implements SofortClient {
+class SofortLibClient implements SofortClient {
 
 	private Sofortueberweisung $api;
 

--- a/tests/Unit/DataAccess/Sofort/Transfer/SofortLibClientTest.php
+++ b/tests/Unit/DataAccess/Sofort/Transfer/SofortLibClientTest.php
@@ -9,15 +9,15 @@ use RuntimeException;
 use Sofort\SofortLib\Sofortueberweisung;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\PaymentContext\DataAccess\Sofort\Transfer\Request;
-use WMDE\Fundraising\PaymentContext\DataAccess\Sofort\Transfer\SofortLibSofortClient;
+use WMDE\Fundraising\PaymentContext\DataAccess\Sofort\Transfer\SofortLibClient;
 
 /**
- * @covers \WMDE\Fundraising\PaymentContext\DataAccess\Sofort\Transfer\SofortLibSofortClient
+ * @covers \WMDE\Fundraising\PaymentContext\DataAccess\Sofort\Transfer\SofortLibClient
  */
 class SofortLibClientTest extends TestCase {
 
 	public function testGet(): void {
-		$client = new SofortLibSofortClient( '47:11:00' );
+		$client = new SofortLibClient( '47:11:00' );
 
 		$amount = Euro::newFromCents( 500 );
 		$amountConvertedToFloat = $amount->getEuroFloat();
@@ -73,7 +73,7 @@ class SofortLibClientTest extends TestCase {
 	}
 
 	public function testWhenApiReturnsErrorAnExceptionWithApiErrorMessageIsThrown(): void {
-		$client = new SofortLibSofortClient( '47:11:00' );
+		$client = new SofortLibClient( '47:11:00' );
 
 		$api = $this->createMock( Sofortueberweisung::class );
 


### PR DESCRIPTION
This sneaked in during an IDE refactor