### PR TITLE
Consolidate Doctrine type registration

### DIFF
--- a/src/PaymentContextFactory.php
+++ b/src/PaymentContextFactory.php
@@ -17,6 +17,13 @@ class PaymentContextFactory {
 		return new XmlDriver( self::DOCTRINE_CLASS_MAPPING_DIRECTORY );
 	}
 
+	public function registerCustomTypes( Connection $connection ): void {
+		$this->registerDoctrineEuroType( $connection );
+		$this->registerDoctrineIbanType( $connection );
+		$this->registerDoctrinePaymentIntervalType( $connection );
+		$this->registerDoctrinePaymentReferenceCodeType( $connection );
+	}
+
 	public function registerDoctrineEuroType( Connection $connection ): void {
 		static $isRegistered = false;
 		if ( $isRegistered ) {
@@ -37,7 +44,7 @@ class PaymentContextFactory {
 		$isRegistered = true;
 	}
 
-	public function registerDoctrinePaymentReferenceType( Connection $connection ): void {
+	public function registerDoctrinePaymentReferenceCodeType( Connection $connection ): void {
 		static $isRegistered = false;
 		if ( $isRegistered ) {
 			return;

--- a/tests/TestPaymentContextFactory.php
+++ b/tests/TestPaymentContextFactory.php
@@ -44,10 +44,7 @@ class TestPaymentContextFactory {
 
 	private function newConnection(): Connection {
 		$connection = DriverManager::getConnection( $this->config['db'] );
-		$this->contextFactory->registerDoctrineEuroType( $connection );
-		$this->contextFactory->registerDoctrinePaymentIntervalType( $connection );
-		$this->contextFactory->registerDoctrinePaymentReferenceType( $connection );
-		$this->contextFactory->registerDoctrineIbanType( $connection );
+		$this->contextFactory->registerCustomTypes( $connection );
 		return $connection;
 	}
 }


### PR DESCRIPTION
Adapt PaymentContextFactory to have one method for registering custom
types with Doctrine. This will make the code in the calling contexts
(donation and membership test environment, DoctrineFactory in
Fundraising App) shorter and less error-prone.