### PR TITLE
Make Bank transfer payments cancellable

### DIFF
--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.BankTransferPayment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.BankTransferPayment.dcm.xml
@@ -2,5 +2,6 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment" table="payments_bank_transfer">
         <field name="paymentReferenceCode" column="payment_reference_code" type="PaymentReferenceCode" nullable="true"/>
+        <field name="isCancelled" type="boolean" column="is_cancelled"/>
     </entity>
 </doctrine-mapping>

--- a/src/Domain/Model/BankTransferPayment.php
+++ b/src/Domain/Model/BankTransferPayment.php
@@ -6,7 +6,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
 
 use WMDE\Euro\Euro;
 
-class BankTransferPayment extends Payment {
+class BankTransferPayment extends Payment implements CancellablePayment {
 
 	private const PAYMENT_METHOD = 'UEB';
 
@@ -16,6 +16,8 @@ class BankTransferPayment extends Payment {
 	 * @var PaymentReferenceCode|null
 	 */
 	private ?PaymentReferenceCode $paymentReferenceCode;
+
+	private bool $isCancelled = false;
 
 	private function __construct( int $id, Euro $amount, PaymentInterval $interval, ?PaymentReferenceCode $paymentReference ) {
 		parent::__construct( $id, $amount, $interval, self::PAYMENT_METHOD );
@@ -47,6 +49,18 @@ class BankTransferPayment extends Payment {
 		// the donation repository code will have to put it there instead of the data blob
 		$paymentReferenceCode = $this->getPaymentReferenceCode();
 		return $paymentReferenceCode ? [ 'ueb_code' => $paymentReferenceCode ] : [];
+	}
+
+	public function isCancelled(): bool {
+		return $this->isCancelled;
+	}
+
+	public function cancel(): void {
+		$this->isCancelled = true;
+	}
+
+	public function isCancellable(): bool {
+		return !$this->isCancelled();
 	}
 
 }

--- a/tests/Unit/Domain/Model/BankTransferPaymentTest.php
+++ b/tests/Unit/Domain/Model/BankTransferPaymentTest.php
@@ -15,23 +15,13 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentReferenceCode;
  */
 class BankTransferPaymentTest extends TestCase {
 	public function testGivenNewPayment_itReturnsFormattedReferenceCode(): void {
-		$payment = BankTransferPayment::create(
-			1,
-			Euro::newFromCents( 1000 ),
-			PaymentInterval::Monthly,
-			new PaymentReferenceCode( 'XW', 'TARARA', 'X' )
-		);
+		$payment = $this->makeBankTransferPayment();
 
 		$this->assertSame( 'XW-TAR-ARA-X', $payment->getPaymentReferenceCode() );
 	}
 
 	public function testGivenAnonymisedPayment_itReturnsFormattedString(): void {
-		$payment = BankTransferPayment::create(
-			1,
-			Euro::newFromCents( 1000 ),
-			PaymentInterval::Monthly,
-			new PaymentReferenceCode( 'XW', 'TARARA', 'X' )
-		);
+		$payment = $this->makeBankTransferPayment();
 		$payment->anonymise();
 
 		$this->assertSame( '', $payment->getPaymentReferenceCode() );
@@ -52,5 +42,30 @@ class BankTransferPaymentTest extends TestCase {
 		);
 
 		$this->assertEquals( $expectedLegacyData, $payment->getLegacyData() );
+	}
+
+	public function testNewPaymentIsNotCancelled(): void {
+		$payment = $this->makeBankTransferPayment();
+
+		$this->assertFalse( $payment->isCancelled() );
+		$this->assertTrue( $payment->isCancellable() );
+	}
+
+	public function testCancelPayment(): void {
+		$payment = $this->makeBankTransferPayment();
+
+		$payment->cancel();
+
+		$this->assertTrue( $payment->isCancelled() );
+		$this->assertFalse( $payment->isCancellable() );
+	}
+
+	private function makeBankTransferPayment(): BankTransferPayment {
+		return BankTransferPayment::create(
+			1,
+			Euro::newFromCents( 1000 ),
+			PaymentInterval::Monthly,
+			new PaymentReferenceCode( 'XW', 'TARARA', 'X' )
+		);
 	}
 }


### PR DESCRIPTION
While they can't be canceled after submitting the donation form,
administrators can cancel it in the Fundraising Operation Center.