### PR TITLE
Add paymentComplete property to SuccessResponse

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,10 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 parameters:
 	ignoreErrors:
-		# A workaround for https://github.com/doctrine/orm/issues/7780
-		# Might be unneccessay in the future with https://github.com/phpstan/phpstan-doctrine/issues/295
+		# A workaround for Doctrine not specifying an UniqueConstraintViolationException being thrown
+		# See https://github.com/doctrine/orm/issues/7780
+		# This rule might be unneccessary in the future with a fixe discussed in
+		# https://github.com/phpstan/phpstan-doctrine/issues/295
 		- message: /Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException is never thrown in the try block/
 		  path: src/DataAccess/DoctrinePaymentRepository.php
 		  count: 1

--- a/src/Domain/Model/BankTransferPayment.php
+++ b/src/Domain/Model/BankTransferPayment.php
@@ -80,4 +80,8 @@ class BankTransferPayment extends Payment implements CancellablePayment {
 		}
 		return LegacyPaymentStatus::BANK_TRANSFER->value;
 	}
+
+	public function isCompleted(): bool {
+		return true;
+	}
 }

--- a/src/Domain/Model/CreditCardPayment.php
+++ b/src/Domain/Model/CreditCardPayment.php
@@ -73,4 +73,8 @@ class CreditCardPayment extends Payment implements BookablePayment {
 			$subtypeValues
 		);
 	}
+
+	public function isCompleted(): bool {
+		return $this->isBooked();
+	}
 }

--- a/src/Domain/Model/DirectDebitPayment.php
+++ b/src/Domain/Model/DirectDebitPayment.php
@@ -87,4 +87,8 @@ class DirectDebitPayment extends Payment implements CancellablePayment {
 		}
 		return LegacyPaymentStatus::DIRECT_DEBIT->value;
 	}
+
+	public function isCompleted(): bool {
+		return true;
+	}
 }

--- a/src/Domain/Model/PayPalPayment.php
+++ b/src/Domain/Model/PayPalPayment.php
@@ -112,4 +112,8 @@ class PayPalPayment extends Payment implements BookablePayment {
 			$subtypeValues
 		);
 	}
+
+	public function isCompleted(): bool {
+		return $this->isBooked();
+	}
 }

--- a/src/Domain/Model/Payment.php
+++ b/src/Domain/Model/Payment.php
@@ -76,4 +76,6 @@ abstract class Payment implements LegacyDataTransformer {
 	 * @return string
 	 */
 	abstract protected function getLegacyPaymentStatus(): string;
+
+	abstract public function isCompleted(): bool;
 }

--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -110,4 +110,8 @@ class SofortPayment extends Payment implements BookablePayment {
 			$subtypeValues
 		);
 	}
+
+	public function isCompleted(): bool {
+		return $this->isBooked();
+	}
 }

--- a/src/UseCases/CreatePayment/CreatePaymentUseCase.php
+++ b/src/UseCases/CreatePayment/CreatePaymentUseCase.php
@@ -5,6 +5,7 @@ namespace WMDE\Fundraising\PaymentContext\UseCases\CreatePayment;
 
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\BookablePayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
@@ -47,7 +48,7 @@ class CreatePaymentUseCase {
 		$paymentProviderURLGenerator = $this->createPaymentProviderURLGenerator( $payment );
 
 		$this->paymentRepository->storePayment( $payment );
-		return new SuccessResponse( $payment->getId(), $paymentProviderURLGenerator );
+		return new SuccessResponse( $payment->getId(), $paymentProviderURLGenerator, $this->getPaymentComplete( $payment ) );
 	}
 
 	/**
@@ -145,6 +146,10 @@ class CreatePaymentUseCase {
 
 	private function createPaymentProviderURLGenerator( Payment $payment ): PaymentProviderURLGenerator {
 		return $this->paymentURLFactory->createURLGenerator( $payment );
+	}
+
+	private function getPaymentComplete( Payment $payment ): bool {
+		return !( $payment instanceof BookablePayment );
 	}
 
 }

--- a/src/UseCases/CreatePayment/CreatePaymentUseCase.php
+++ b/src/UseCases/CreatePayment/CreatePaymentUseCase.php
@@ -5,7 +5,6 @@ namespace WMDE\Fundraising\PaymentContext\UseCases\CreatePayment;
 
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment;
-use WMDE\Fundraising\PaymentContext\Domain\Model\BookablePayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
@@ -48,7 +47,7 @@ class CreatePaymentUseCase {
 		$paymentProviderURLGenerator = $this->createPaymentProviderURLGenerator( $payment );
 
 		$this->paymentRepository->storePayment( $payment );
-		return new SuccessResponse( $payment->getId(), $paymentProviderURLGenerator, $this->getPaymentComplete( $payment ) );
+		return new SuccessResponse( $payment->getId(), $paymentProviderURLGenerator, $payment->isCompleted() );
 	}
 
 	/**
@@ -147,9 +146,4 @@ class CreatePaymentUseCase {
 	private function createPaymentProviderURLGenerator( Payment $payment ): PaymentProviderURLGenerator {
 		return $this->paymentURLFactory->createURLGenerator( $payment );
 	}
-
-	private function getPaymentComplete( Payment $payment ): bool {
-		return !( $payment instanceof BookablePayment );
-	}
-
 }

--- a/src/UseCases/CreatePayment/SuccessResponse.php
+++ b/src/UseCases/CreatePayment/SuccessResponse.php
@@ -8,7 +8,8 @@ use WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator\PaymentProviderUR
 class SuccessResponse {
 	public function __construct(
 		public readonly int $paymentId,
-		public readonly PaymentProviderURLGenerator $paymentProviderURLGenerator
+		public readonly PaymentProviderURLGenerator $paymentProviderURLGenerator,
+		public readonly bool $paymentComplete
 	) {
 	}
 }

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -4,10 +4,13 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\PaymentContext\Tests;
 
+/**
+ * @phpstan-import-type Params from \Doctrine\DBAL\DriverManager
+ */
 class TestEnvironment {
 
 	/**
-	 * @var array{db:array<string,mixed>}
+	 * @var array{db:Params}
 	 */
 	private array $config;
 	private TestPaymentContextFactory $factory;
@@ -33,7 +36,7 @@ class TestEnvironment {
 	}
 
 	/**
-	 * @param array{db:array<string,mixed>} $config
+	 * @param array{db:Params} $config
 	 */
 	private function __construct( array $config ) {
 		$this->config = $config;

--- a/tests/TestPaymentContextFactory.php
+++ b/tests/TestPaymentContextFactory.php
@@ -11,6 +11,9 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Setup;
 use WMDE\Fundraising\PaymentContext\PaymentContextFactory;
 
+/**
+ * @phpstan-import-type Params from DriverManager
+ */
 class TestPaymentContextFactory {
 
 	private Configuration $doctrineConfig;
@@ -18,7 +21,7 @@ class TestPaymentContextFactory {
 	private ?EntityManager $entityManager;
 
 	/**
-	 * @param array{db:array<string,mixed>} $config
+	 * @param array{db:Params} $config
 	 */
 	public function __construct( private array $config ) {
 		$this->doctrineConfig = Setup::createConfiguration( true );

--- a/tests/Unit/Domain/Model/BankTransferPaymentTest.php
+++ b/tests/Unit/Domain/Model/BankTransferPaymentTest.php
@@ -107,4 +107,10 @@ class BankTransferPaymentTest extends TestCase {
 
 		$this->assertEquals( $expectedOutput, $payment->getDisplayValues() );
 	}
+
+	public function testBankTransferPaymentsAreAlwaysImmediatelyCompletedPayments(): void {
+		$payment = $this->makeBankTransferPayment();
+
+		$this->assertTrue( $payment->isCompleted() );
+	}
 }

--- a/tests/Unit/Domain/Model/CreditCardPaymentTest.php
+++ b/tests/Unit/Domain/Model/CreditCardPaymentTest.php
@@ -19,9 +19,10 @@ class CreditCardPaymentTest extends TestCase {
 
 	private const OTHER_TRANSACTION_ID = '3388998877';
 
-	public function testNewCreditCardPaymentsAreNotBooked(): void {
+	public function testNewCreditCardPaymentsAreNotBookedAndIncomplete(): void {
 		$creditCardPayment = new CreditCardPayment( 1, Euro::newFromInt( 1000 ), PaymentInterval::Monthly );
 		$this->assertTrue( $creditCardPayment->canBeBooked( [] ) );
+		$this->assertFalse( $creditCardPayment->isCompleted() );
 	}
 
 	public function testCompletePaymentWithOutTransactionIdFails(): void {
@@ -64,6 +65,7 @@ class CreditCardPaymentTest extends TestCase {
 		// Credit cards get their valuation date from current time instead of transaction data
 		$this->assertNotNull( $creditCardPayment->getValuationDate() );
 		$this->assertEqualsWithDelta( time(), $creditCardPayment->getValuationDate()->getTimestamp(), 5 );
+		$this->assertTrue( $creditCardPayment->isCompleted() );
 	}
 
 	public function testGivenBookedPayment_paymentLegacyDataIsNonEmptyArray(): void {

--- a/tests/Unit/Domain/Model/DirectDebitPaymentTest.php
+++ b/tests/Unit/Domain/Model/DirectDebitPaymentTest.php
@@ -90,6 +90,12 @@ class DirectDebitPaymentTest extends TestCase {
 		$this->assertEquals( $expectedOutput, $payment->getDisplayValues() );
 	}
 
+	public function testDirectDebitPaymentsAreAlwaysImmediatelyCompletedPayments(): void {
+		$payment = $this->makeDirectDebitPayment();
+
+		$this->assertTrue( $payment->isCompleted() );
+	}
+
 	private function makeDirectDebitPayment(): DirectDebitPayment {
 		return DirectDebitPayment::create(
 			self::PAYMENT_ID,

--- a/tests/Unit/Domain/Model/PayPalPaymentTest.php
+++ b/tests/Unit/Domain/Model/PayPalPaymentTest.php
@@ -21,9 +21,10 @@ class PayPalPaymentTest extends TestCase {
 	private const PAYER_ID = '42';
 	private const FOLLOWUP_PAYMENT_ID = 99;
 
-	public function testNewPayPalPaymentsAreUnbooked(): void {
+	public function testNewPayPalPaymentsAreUnbookedAndIncomplete(): void {
 		$payment = new PayPalPayment( 1, Euro::newFromCents( 1000 ), PaymentInterval::OneTime );
 		$this->assertTrue( $payment->canBeBooked( PayPalPaymentBookingData::newValidBookingData() ) );
+		$this->assertFalse( $payment->isCompleted() );
 	}
 
 	public function testCompletePaymentWithEmptyTransactionDataFails(): void {
@@ -41,6 +42,7 @@ class PayPalPaymentTest extends TestCase {
 		$payment->bookPayment( PayPalPaymentBookingData::newValidBookingData(), new DummyPaymentIdRepository() );
 
 		$this->assertTrue( $payment->isBooked() );
+		$this->assertTrue( $payment->isCompleted() );
 	}
 
 	public function testBookPaymentSetsValuationDate(): void {

--- a/tests/Unit/Domain/Model/PaymentTest.php
+++ b/tests/Unit/Domain/Model/PaymentTest.php
@@ -81,6 +81,10 @@ class PaymentTest extends TestCase {
 			protected function getLegacyPaymentStatus(): string {
 				return 'Y';
 			}
+
+			public function isCompleted(): bool {
+				return false;
+			}
 		};
 	}
 }

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -31,10 +31,11 @@ class SofortPaymentTest extends TestCase {
 		$this->assertSame( '', $sofortPayment->getPaymentReferenceCode() );
 	}
 
-	public function testNewSofortPaymentsAreUnbooked(): void {
+	public function testNewSofortPaymentsAreUnbookedAndIncomplete(): void {
 		$sofortPayment = $this->makeSofortPayment();
 
 		$this->assertTrue( $sofortPayment->canBeBooked( $this->makeValidTransactionData() ) );
+		$this->assertFalse( $sofortPayment->isCompleted() );
 	}
 
 	public function testGivenNonOneTimePaymentIntervalThrowsException(): void {
@@ -48,6 +49,7 @@ class SofortPaymentTest extends TestCase {
 
 		$sofortPayment->bookPayment( $this->makeValidTransactionData(), new DummyPaymentIdRepository() );
 
+		$this->assertTrue( $sofortPayment->isCompleted() );
 		$this->assertFalse( $sofortPayment->canBeBooked( $this->makeValidTransactionData() ) );
 	}
 


### PR DESCRIPTION
The calling bounded context (donation/membership) needs to know if the
payment process is finished or if there are more steps (e.g. going to
the page of the payment providing and completing the payment there).
This will be used by the donation/membership bounded context to
determine if it should send a notification.