### PR TITLE
Create new booked PayPal payments

### DIFF
--- a/src/UseCases/CreateBookedPayPalPayment/CreateBookedPayPalPaymentUseCase.php
+++ b/src/UseCases/CreateBookedPayPalPayment/CreateBookedPayPalPaymentUseCase.php
@@ -1,0 +1,57 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment;
+
+use WMDE\Euro\Euro;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentRepository;
+use WMDE\Fundraising\PaymentContext\Domain\Repositories\PaymentIDRepository;
+use WMDE\Fundraising\PaymentContext\Services\ExternalVerificationService\PayPal\PayPalVerificationService;
+
+/**
+ * This use case will be used to book incoming PayPal payments without any reference where we can look up a payment ID.
+ *
+ * This happens when a user does **not** use the Fundraising App, but instead uses the
+ * PayPal app/website to send money to the donation email address of WMDE.
+ *
+ * Currently, the code outside the payment bounded context will use this to create a donation.
+ * You can search for "PayPal" in the donation bounded context to find the call for this use case.
+ */
+class CreateBookedPayPalPaymentUseCase {
+	public function __construct(
+		private PaymentRepository $repository,
+		private PaymentIDRepository $idGenerator,
+		private PayPalVerificationService $verificationService
+	) {
+	}
+
+	/**
+	 * @param int $amountInCents
+	 * @param array<string,mixed> $transactionData
+	 * @return SuccessResponse|FailureResponse
+	 */
+	public function bookNewPayment( int $amountInCents, array $transactionData ): SuccessResponse|FailureResponse {
+		try{
+			$parsedAmount = Euro::newFromCents( $amountInCents );
+		} catch ( \InvalidArgumentException $exception ) {
+			return new FailureResponse( $exception->getMessage() );
+		}
+
+		$payment = new PayPalPayment( $this->idGenerator->getNewID(), $parsedAmount, PaymentInterval::OneTime );
+		$verificationResponse = $this->verificationService->validate( $transactionData );
+		if ( !$verificationResponse->isValid() ) {
+			return new FailureResponse( $verificationResponse->getMessage() );
+		}
+
+		$payment->bookPayment(
+			$transactionData,
+			new FailingPaymentIdRepository( "Immediately booked PayPal payments must not create followup payments." )
+		);
+		$this->repository->storePayment( $payment );
+
+		return new SuccessResponse( $payment->getId() );
+	}
+
+}

--- a/src/UseCases/CreateBookedPayPalPayment/FailingPaymentIdRepository.php
+++ b/src/UseCases/CreateBookedPayPalPayment/FailingPaymentIdRepository.php
@@ -1,0 +1,17 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment;
+
+use WMDE\Fundraising\PaymentContext\Domain\Repositories\PaymentIDRepository;
+
+class FailingPaymentIdRepository implements PaymentIDRepository {
+
+	public function __construct( private string $message ) {
+	}
+
+	public function getNewID(): int {
+		throw new \LogicException( $this->message );
+	}
+
+}

--- a/src/UseCases/CreateBookedPayPalPayment/FailureResponse.php
+++ b/src/UseCases/CreateBookedPayPalPayment/FailureResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment;
+
+class FailureResponse {
+	public function __construct(
+		public readonly string $message
+	) {
+	}
+}

--- a/src/UseCases/CreateBookedPayPalPayment/SuccessResponse.php
+++ b/src/UseCases/CreateBookedPayPalPayment/SuccessResponse.php
@@ -1,0 +1,10 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment;
+
+class SuccessResponse {
+
+	public function __construct( public readonly int $paymentId ) {
+	}
+}

--- a/tests/Unit/UseCases/CreateBookedPayPalPaymentUseCase/CreateBookedPayPalPaymentUseCaseTest.php
+++ b/tests/Unit/UseCases/CreateBookedPayPalPaymentUseCase/CreateBookedPayPalPaymentUseCaseTest.php
@@ -1,0 +1,84 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Unit\UseCases\CreateBookedPayPalPaymentUseCase;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentRepository;
+use WMDE\Fundraising\PaymentContext\Services\ExternalVerificationService\PayPal\PayPalVerificationService;
+use WMDE\Fundraising\PaymentContext\Tests\Data\PayPalPaymentBookingData;
+use WMDE\Fundraising\PaymentContext\Tests\Fixtures\PaymentRepositorySpy;
+use WMDE\Fundraising\PaymentContext\Tests\Fixtures\SequentialPaymentIDRepository;
+use WMDE\Fundraising\PaymentContext\UseCases\BookPayment\VerificationResponse;
+use WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\CreateBookedPayPalPaymentUseCase;
+use WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\FailureResponse;
+use WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\SuccessResponse;
+
+/**
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\CreateBookedPayPalPaymentUseCase
+ */
+class CreateBookedPayPalPaymentUseCaseTest extends TestCase {
+	private const PAYMENT_ID = 5;
+
+	public function testGivenSuccessfulVerification(): void {
+		$repository = new PaymentRepositorySpy( [] );
+		$useCase = new CreateBookedPayPalPaymentUseCase(
+			$repository,
+			new SequentialPaymentIDRepository( self::PAYMENT_ID ),
+			$this->makeSucceedingVerifier()
+		);
+
+		$result = $useCase->bookNewPayment( 999, PayPalPaymentBookingData::newValidBookingData() );
+
+		$storedPayment = $repository->getPaymentById( self::PAYMENT_ID );
+
+		$this->assertInstanceOf( SuccessResponse::class, $result );
+		$this->assertSame( self::PAYMENT_ID, $result->paymentId );
+		$this->assertInstanceOf( PayPalPayment::class, $storedPayment );
+		$this->assertTrue( $storedPayment->isBooked() );
+		$this->assertEquals( 999, $storedPayment->getAmount()->getEuroCents() );
+		$this->assertEquals( PaymentInterval::OneTime, $storedPayment->getInterval() );
+	}
+
+	public function testGivenFailingVerification(): void {
+		$repository = $this->createMock( PaymentRepository::class );
+		$repository->expects( $this->never() )->method( 'storePayment' );
+		$useCase = new CreateBookedPayPalPaymentUseCase(
+			$repository,
+			new SequentialPaymentIDRepository( self::PAYMENT_ID ),
+			$this->makeFailingVerifier()
+		);
+
+		$result = $useCase->bookNewPayment( 999, PayPalPaymentBookingData::newValidBookingData() );
+
+		$this->assertInstanceOf( FailureResponse::class, $result );
+	}
+
+	public function testGivenInvalidPaymentAmount_returnsFailureResponse(): void {
+		$repository = $this->createMock( PaymentRepository::class );
+		$repository->expects( $this->never() )->method( 'storePayment' );
+		$useCase = new CreateBookedPayPalPaymentUseCase(
+			$repository,
+			new SequentialPaymentIDRepository( self::PAYMENT_ID ),
+			$this->makeSucceedingVerifier()
+		);
+
+		$result = $useCase->bookNewPayment( -5, PayPalPaymentBookingData::newValidBookingData() );
+
+		$this->assertInstanceOf( FailureResponse::class, $result );
+	}
+
+	private function makeSucceedingVerifier(): PayPalVerificationService {
+		$validator = $this->createMock( PayPalVerificationService::class );
+		$validator->method( 'validate' )->willReturn( VerificationResponse::newSuccessResponse() );
+		return $validator;
+	}
+
+	private function makeFailingVerifier(): PayPalVerificationService {
+		$validator = $this->createMock( PayPalVerificationService::class );
+		$validator->method( 'validate' )->willReturn( VerificationResponse::newFailureResponse( '' ) );
+		return $validator;
+	}
+}


### PR DESCRIPTION
Add a new use case that'll allow people to donate by using the PayPal
app instead of the Fundraising App. This combines the "Create Payment"
and "Book Payment" functionality, but has a different internal logic:

- we only need an amount to create a one-time PayPal payments
- we verify first with PayPal that the booking request originated
  with them.
- we do not support followup payments when booking (by using a failing
  id generator), because these payments are never followup payments.
- we return the payment ID in the success response

This is part of https://phabricator.wikimedia.org/T304731