### PR TITLE
Remove exception from CancelPaymentUseCase

### DIFF
--- a/src/UseCases/CancelPayment/CancelPaymentUseCase.php
+++ b/src/UseCases/CancelPayment/CancelPaymentUseCase.php
@@ -23,12 +23,8 @@ class CancelPaymentUseCase {
 			return new FailureResponse( $e->getMessage() );
 		}
 
-		if ( !( $payment instanceof CancellablePayment ) ) {
-			throw new \RuntimeException( 'Tried to cancel an non-cancellable payment' );
-		}
-
-		if ( !$payment->isCancellable() ) {
-			return new FailureResponse( 'This payment is already cancelled' );
+		if ( !( $payment instanceof CancellablePayment ) || !$payment->isCancellable() ) {
+			return new FailureResponse( 'This payment can\'t be canceled - it is already cancelled or does not support cancellation' );
 		}
 
 		$payment->cancel();

--- a/tests/Unit/UseCases/CancelPayment/CancelPaymentUseCaseTest.php
+++ b/tests/Unit/UseCases/CancelPayment/CancelPaymentUseCaseTest.php
@@ -64,14 +64,14 @@ class CancelPaymentUseCaseTest extends TestCase {
 		$this->assertSame( 'Me fail English, that\'s unpossible', $response->message );
 	}
 
-	public function testCancelNonCancellablePaymentThrowsException(): void {
+	public function testCancelNonCancellablePaymentReturnsFailureResponse(): void {
 		$payment = new PayPalPayment( 1, Euro::newFromCents( 100 ), PaymentInterval::OneTime );
 		$repository = new PaymentRepositorySpy( [ 1 => $payment ] );
 
 		$useCase = new CancelPaymentUseCase( $repository );
+		$response = $useCase->cancelPayment( 1 );
 
-		$this->expectException( \RuntimeException::class );
-		$useCase->cancelPayment( 1 );
+		$this->assertInstanceOf( FailureResponse::class, $response );
 	}
 
 	private function makeDirectDebitPayment(): DirectDebitPayment {


### PR DESCRIPTION
A calling class shouldn't have to worry if a payment implements the CancellablePayment interface

Ticket: https://phabricator.wikimedia.org/T305825