### PR TITLE
Modernize database setup

### DIFF
--- a/src/PaymentContextFactory.php
+++ b/src/PaymentContextFactory.php
@@ -11,8 +11,13 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
 class PaymentContextFactory {
 
-	private const DOCTRINE_CLASS_MAPPING_DIRECTORY = __DIR__ . '/../config/DoctrineClassMapping';
+	public const DOCTRINE_CLASS_MAPPING_DIRECTORY = __DIR__ . '/../config/DoctrineClassMapping';
 
+	/**
+	 * @return MappingDriver
+	 * @deprecated We no longer have a mix of mapping drivers.
+	 *     Use {@see XmlDriver} with an array containing {@see PaymentContextFactory::DOCTRINE_CLASS_MAPPING_DIRECTORY}} instead.
+	 */
 	public function newMappingDriver(): MappingDriver {
 		return new XmlDriver( self::DOCTRINE_CLASS_MAPPING_DIRECTORY );
 	}

--- a/tests/TestPaymentContextFactory.php
+++ b/tests/TestPaymentContextFactory.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\ORMSetup;
 use WMDE\Fundraising\PaymentContext\PaymentContextFactory;
 
 /**
@@ -24,7 +24,10 @@ class TestPaymentContextFactory {
 	 * @param array{db:Params} $config
 	 */
 	public function __construct( private array $config ) {
-		$this->doctrineConfig = Setup::createConfiguration( true );
+		$this->doctrineConfig = ORMSetup::createXMLMetadataConfiguration(
+			[ PaymentContextFactory::DOCTRINE_CLASS_MAPPING_DIRECTORY ],
+			true
+		);
 		$this->contextFactory = new PaymentContextFactory();
 		$this->entityManager = null;
 	}
@@ -37,7 +40,6 @@ class TestPaymentContextFactory {
 	}
 
 	public function newEntityManager(): EntityManager {
-		$this->doctrineConfig->setMetadataDriverImpl( $this->contextFactory->newMappingDriver() );
 		return EntityManager::create( $this->newConnection(), $this->doctrineConfig );
 	}
 


### PR DESCRIPTION
Use ORMSetup instead of the deprecated setup.

Deprecate newMappingDriver - we can now use the
DOCTRINE_CLASS_MAPPING_DIRECTORY directly

A we also need a public mapping directory for generating migrations in
https://phabricator.wikimedia.org/T305060