### PR TITLE
Change DomainSpecificPaymentValidator injection

### DIFF
--- a/src/Domain/DomainSpecificPaymentValidator.php
+++ b/src/Domain/DomainSpecificPaymentValidator.php
@@ -8,5 +8,5 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\FunValidators\ValidationResponse;
 
 interface DomainSpecificPaymentValidator {
-	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentTypes $paymentType ): ValidationResponse;
+	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentType $paymentType ): ValidationResponse;
 }

--- a/src/Domain/DomainSpecificPaymentValidator.php
+++ b/src/Domain/DomainSpecificPaymentValidator.php
@@ -8,5 +8,5 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\FunValidators\ValidationResponse;
 
 interface DomainSpecificPaymentValidator {
-	public function validatePaymentData( Euro $amount, PaymentInterval $interval ): ValidationResponse;
+	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentTypes $paymentType ): ValidationResponse;
 }

--- a/src/Domain/PaymentType.php
+++ b/src/Domain/PaymentType.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\PaymentContext\Domain;
 
-enum PaymentTypes: string
+enum PaymentType: string
 {
 	case DirectDebit = 'BEZ';
 	case BankTransfer = 'UEB';

--- a/src/Domain/PaymentValidator.php
+++ b/src/Domain/PaymentValidator.php
@@ -46,7 +46,7 @@ class PaymentValidator {
 	}
 
 	private function validatePaymentType( string $paymentType ): void {
-		if ( PaymentTypes::tryFrom( $paymentType ) === null ) {
+		if ( PaymentType::tryFrom( $paymentType ) === null ) {
 			$this->errors[] = new ConstraintViolation( $paymentType, 'Unknown payment type', self::SOURCE_PAYMENT_TYPE );
 		}
 	}
@@ -55,7 +55,7 @@ class PaymentValidator {
 		return $validator->validatePaymentData(
 			Euro::newFromCents( $amount ),
 			PaymentInterval::from( $interval ),
-			PaymentTypes::from( $paymentType )
+			PaymentType::from( $paymentType )
 		);
 	}
 }

--- a/src/Domain/PaymentValidator.php
+++ b/src/Domain/PaymentValidator.php
@@ -18,12 +18,7 @@ class PaymentValidator {
 	 */
 	private array $errors = [];
 
-	public function __construct(
-		private DomainSpecificPaymentValidator $domainValidator
-	) {
-	}
-
-	public function validatePaymentData( int $amount, int $interval, string $paymentType ): ValidationResponse {
+	public function validatePaymentData( int $amount, int $interval, string $paymentType, DomainSpecificPaymentValidator $domainSpecificPaymentValidator ): ValidationResponse {
 		$this->errors = [];
 		$this->validateAmount( $amount );
 		$this->validateInterval( $interval );
@@ -33,7 +28,7 @@ class PaymentValidator {
 			return ValidationResponse::newFailureResponse( $this->errors );
 		}
 
-		return $this->validateDomain( $amount, $interval );
+		return $this->validateDomain( $amount, $interval, $paymentType, $domainSpecificPaymentValidator );
 	}
 
 	private function validateAmount( int $amount ): void {
@@ -56,7 +51,11 @@ class PaymentValidator {
 		}
 	}
 
-	private function validateDomain( int $amount, int $interval ): ValidationResponse {
-		return $this->domainValidator->validatePaymentData( Euro::newFromCents( $amount ), PaymentInterval::from( $interval ) );
+	private function validateDomain( int $amount, int $interval, string $paymentType, DomainSpecificPaymentValidator $validator ): ValidationResponse {
+		return $validator->validatePaymentData(
+			Euro::newFromCents( $amount ),
+			PaymentInterval::from( $interval ),
+			PaymentTypes::from( $paymentType )
+		);
 	}
 }

--- a/src/UseCases/CreatePayment/CreatePaymentUseCase.php
+++ b/src/UseCases/CreatePayment/CreatePaymentUseCase.php
@@ -33,7 +33,7 @@ class CreatePaymentUseCase {
 	}
 
 	public function createPayment( PaymentCreationRequest $request ): SuccessResponse|FailureResponse {
-		$validationResult = $this->paymentValidator->validatePaymentData( $request->amountInEuroCents, $request->interval, $request->paymentType );
+		$validationResult = $this->paymentValidator->validatePaymentData( $request->amountInEuroCents, $request->interval, $request->paymentType, $request->getDomainSpecificPaymentValidator() );
 		if ( !$validationResult->isSuccessful() ) {
 			return new FailureResponse( $validationResult->getValidationErrors()[0]->getMessageIdentifier() );
 		}

--- a/src/UseCases/CreatePayment/CreatePaymentUseCase.php
+++ b/src/UseCases/CreatePayment/CreatePaymentUseCase.php
@@ -14,7 +14,7 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentReferenceCodeGenerator;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentRepository;
-use WMDE\Fundraising\PaymentContext\Domain\PaymentTypes;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator\PaymentProviderURLGenerator;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator\UrlGeneratorFactory;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentValidator;
@@ -56,12 +56,12 @@ class CreatePaymentUseCase {
 	 * @throws PaymentCreationException
 	 */
 	private function tryCreatePayment( PaymentCreationRequest $request ): Payment {
-		return match ( PaymentTypes::tryFrom( $request->paymentType ) ) {
-			PaymentTypes::CreditCard => $this->createCreditCardPayment( $request ),
-			PaymentTypes::Paypal => $this->createPayPalPayment( $request ),
-			PaymentTypes::Sofort => $this->createSofortPayment( $request ),
-			PaymentTypes::BankTransfer => $this->createBankTransferPayment( $request ),
-			PaymentTypes::DirectDebit => $this->createDirectDebitPayment( $request ),
+		return match ( PaymentType::tryFrom( $request->paymentType ) ) {
+			PaymentType::CreditCard => $this->createCreditCardPayment( $request ),
+			PaymentType::Paypal => $this->createPayPalPayment( $request ),
+			PaymentType::Sofort => $this->createSofortPayment( $request ),
+			PaymentType::BankTransfer => $this->createBankTransferPayment( $request ),
+			PaymentType::DirectDebit => $this->createDirectDebitPayment( $request ),
 			default => throw new \LogicException( sprintf(
 				'Invalid payment type not caught by %s: %s', PaymentValidator::class, $request->paymentType
 			) )

--- a/src/UseCases/CreatePayment/PaymentCreationRequest.php
+++ b/src/UseCases/CreatePayment/PaymentCreationRequest.php
@@ -3,7 +3,12 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\PaymentContext\UseCases\CreatePayment;
 
+use WMDE\Fundraising\PaymentContext\Domain\DomainSpecificPaymentValidator;
+
 class PaymentCreationRequest {
+
+	private DomainSpecificPaymentValidator $domainSpecificPaymentValidator;
+
 	public function __construct(
 		public readonly int $amountInEuroCents,
 		public readonly int $interval,
@@ -13,4 +18,13 @@ class PaymentCreationRequest {
 		public readonly string $transferCodePrefix = ''
 	) {
 	}
+
+	public function getDomainSpecificPaymentValidator(): DomainSpecificPaymentValidator {
+		return $this->domainSpecificPaymentValidator;
+	}
+
+	public function setDomainSpecificPaymentValidator( DomainSpecificPaymentValidator $domainSpecificPaymentValidator ): void {
+		$this->domainSpecificPaymentValidator = $domainSpecificPaymentValidator;
+	}
+
 }

--- a/tests/Fixtures/FailingDomainSpecificValidator.php
+++ b/tests/Fixtures/FailingDomainSpecificValidator.php
@@ -6,12 +6,12 @@ namespace WMDE\Fundraising\PaymentContext\Tests\Fixtures;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\PaymentContext\Domain\DomainSpecificPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
-use WMDE\Fundraising\PaymentContext\Domain\PaymentTypes;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\FunValidators\ConstraintViolation;
 use WMDE\FunValidators\ValidationResponse;
 
 class FailingDomainSpecificValidator implements DomainSpecificPaymentValidator {
-	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentTypes $paymentType ): ValidationResponse {
+	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentType $paymentType ): ValidationResponse {
 		return ValidationResponse::newFailureResponse( [
 			new ConstraintViolation(
 				$amount->getEuroString(),

--- a/tests/Fixtures/FailingDomainSpecificValidator.php
+++ b/tests/Fixtures/FailingDomainSpecificValidator.php
@@ -6,11 +6,12 @@ namespace WMDE\Fundraising\PaymentContext\Tests\Fixtures;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\PaymentContext\Domain\DomainSpecificPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentTypes;
 use WMDE\FunValidators\ConstraintViolation;
 use WMDE\FunValidators\ValidationResponse;
 
 class FailingDomainSpecificValidator implements DomainSpecificPaymentValidator {
-	public function validatePaymentData( Euro $amount, PaymentInterval $interval ): ValidationResponse {
+	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentTypes $paymentType ): ValidationResponse {
 		return ValidationResponse::newFailureResponse( [
 			new ConstraintViolation(
 				$amount->getEuroString(),

--- a/tests/Fixtures/SucceedingDomainSpecificValidator.php
+++ b/tests/Fixtures/SucceedingDomainSpecificValidator.php
@@ -6,10 +6,11 @@ namespace WMDE\Fundraising\PaymentContext\Tests\Fixtures;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\PaymentContext\Domain\DomainSpecificPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentTypes;
 use WMDE\FunValidators\ValidationResponse;
 
 class SucceedingDomainSpecificValidator implements DomainSpecificPaymentValidator {
-	public function validatePaymentData( Euro $amount, PaymentInterval $interval ): ValidationResponse {
+	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentTypes $paymentType ): ValidationResponse {
 		return ValidationResponse::newSuccessResponse();
 	}
 

--- a/tests/Fixtures/SucceedingDomainSpecificValidator.php
+++ b/tests/Fixtures/SucceedingDomainSpecificValidator.php
@@ -6,11 +6,11 @@ namespace WMDE\Fundraising\PaymentContext\Tests\Fixtures;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\PaymentContext\Domain\DomainSpecificPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
-use WMDE\Fundraising\PaymentContext\Domain\PaymentTypes;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\FunValidators\ValidationResponse;
 
 class SucceedingDomainSpecificValidator implements DomainSpecificPaymentValidator {
-	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentTypes $paymentType ): ValidationResponse {
+	public function validatePaymentData( Euro $amount, PaymentInterval $interval, PaymentType $paymentType ): ValidationResponse {
 		return ValidationResponse::newSuccessResponse();
 	}
 

--- a/tests/Unit/Domain/PaymentValidatorTest.php
+++ b/tests/Unit/Domain/PaymentValidatorTest.php
@@ -18,9 +18,14 @@ class PaymentValidatorTest extends TestCase {
 	private const VALID_PAYMENT_TYPE = 'UEB';
 
 	public function testAmountValidation(): void {
-		$validator = new PaymentValidator( $this->makeSucceedingDomainSpecificValidator() );
+		$validator = new PaymentValidator();
 
-		$result = $validator->validatePaymentData( -1, self::VALID_INTERVAL, self::VALID_PAYMENT_TYPE );
+		$result = $validator->validatePaymentData(
+			-1,
+			self::VALID_INTERVAL,
+			self::VALID_PAYMENT_TYPE,
+			$this->makeSucceedingDomainSpecificValidator()
+		);
 
 		$this->assertFalse( $result->isSuccessful() );
 		$errors = $result->getValidationErrors();
@@ -29,9 +34,14 @@ class PaymentValidatorTest extends TestCase {
 	}
 
 	public function testIntervalValidation(): void {
-		$validator = new PaymentValidator( $this->makeSucceedingDomainSpecificValidator() );
+		$validator = new PaymentValidator();
 
-		$result = $validator->validatePaymentData( self::VALID_AMOUNT, 99, self::VALID_PAYMENT_TYPE );
+		$result = $validator->validatePaymentData(
+			self::VALID_AMOUNT,
+			99,
+			self::VALID_PAYMENT_TYPE,
+			$this->makeSucceedingDomainSpecificValidator()
+		);
 
 		$this->assertFalse( $result->isSuccessful() );
 		$errors = $result->getValidationErrors();
@@ -40,9 +50,14 @@ class PaymentValidatorTest extends TestCase {
 	}
 
 	public function testPaymentTypeValidation(): void {
-		$validator = new PaymentValidator( $this->makeSucceedingDomainSpecificValidator() );
+		$validator = new PaymentValidator();
 
-		$result = $validator->validatePaymentData( self::VALID_AMOUNT, self::VALID_INTERVAL, 'TRA$HCOIN' );
+		$result = $validator->validatePaymentData(
+			self::VALID_AMOUNT,
+			self::VALID_INTERVAL,
+			'TRA$HCOIN',
+			$this->makeSucceedingDomainSpecificValidator()
+		);
 
 		$this->assertFalse( $result->isSuccessful() );
 		$errors = $result->getValidationErrors();
@@ -51,9 +66,14 @@ class PaymentValidatorTest extends TestCase {
 	}
 
 	public function testDomainValidation(): void {
-		$validator = new PaymentValidator( $this->makeFailingDomainSpecificValidator() );
+		$validator = new PaymentValidator();
 
-		$result = $validator->validatePaymentData( self::VALID_AMOUNT, self::VALID_INTERVAL, self::VALID_PAYMENT_TYPE );
+		$result = $validator->validatePaymentData(
+			self::VALID_AMOUNT,
+			self::VALID_INTERVAL,
+			self::VALID_PAYMENT_TYPE,
+			$this->makeFailingDomainSpecificValidator()
+		);
 
 		$this->assertFalse( $result->isSuccessful() );
 		$errors = $result->getValidationErrors();

--- a/tests/Unit/UseCases/CreatePayment/CreatePaymentUseCaseBuilder.php
+++ b/tests/Unit/UseCases/CreatePayment/CreatePaymentUseCaseBuilder.php
@@ -11,11 +11,9 @@ use WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator\NullGenerator;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator\UrlGeneratorFactory;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Repositories\PaymentIDRepository;
-use WMDE\Fundraising\PaymentContext\Tests\Fixtures\FailingDomainSpecificValidator;
 use WMDE\Fundraising\PaymentContext\Tests\Fixtures\FailingIbanValidator;
 use WMDE\Fundraising\PaymentContext\Tests\Fixtures\FixedPaymentReferenceCodeGenerator;
 use WMDE\Fundraising\PaymentContext\Tests\Fixtures\PaymentRepositorySpy;
-use WMDE\Fundraising\PaymentContext\Tests\Fixtures\SucceedingDomainSpecificValidator;
 use WMDE\Fundraising\PaymentContext\Tests\Fixtures\SucceedingIbanValidator;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\CreatePaymentUseCase;
 use WMDE\Fundraising\PaymentContext\UseCases\ValidateIban\ValidateIbanUseCase;
@@ -119,12 +117,6 @@ class CreatePaymentUseCaseBuilder {
 	}
 
 	private function makePaymentValidator(): PaymentValidator {
-		return new PaymentValidator( new SucceedingDomainSpecificValidator() );
+		return new PaymentValidator();
 	}
-
-	public function withFailingDomainValidator(): self {
-		$this->paymentValidator = new PaymentValidator( new FailingDomainSpecificValidator() );
-		return $this;
-	}
-
 }


### PR DESCRIPTION
Inject DomainSpecificPaymentValidator through a mandatory setter
dependency in PaymentCreationRequest instead of a constructor parameter
of PaymentValidator.

This has the following benefits:

- It allows the use cases (CreateDonation/CreateMembership) to
  initialize the domain-specific validation instead of relying on the
  central dependency injection (FunFunFactory) to "do the right thing".
- It allows the use cases to initialize the domain specific validation
  with additional parameters from the domain request. Example: The
  membership minimum amount depends on the membership type.

Add PaymentType as a third parameter to the
DomainSpecificPaymentValidator interface. This will allow the
domain-specific validators to restrict payment types to certain domains
(e.g. Memberships allow only direct debit payments)