### PR TITLE
Speed up database tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - MARIADB_USER=fundraising
       - MARIADB_PASSWORD=INSECURE PASSWORD
       - MARIADB_DATABASE=fundraising
+    tmpfs: /var/lib/mysql:rw
     ports:
       - '3309:3306'
     expose:


### PR DESCRIPTION
Using `tmpfs` for the MariaDB data directory speeds tests up by a factor
of 4x-20x, because `tmpfs` puts data in memory instead of the disk,
making IO much faster.