### PR TITLE
Improve SofortConfig constructor

### DIFF
--- a/src/Domain/PaymentUrlGenerator/Sofort.php
+++ b/src/Domain/PaymentUrlGenerator/Sofort.php
@@ -30,7 +30,13 @@ class Sofort implements PaymentProviderURLGenerator {
 		$request = new Request();
 		$request->setAmount( $this->payment->getAmount() );
 		$request->setCurrencyCode( self::CURRENCY );
-		$request->setReasons( [ $this->config->getReasonText(), $this->payment->getPaymentReferenceCode() ] );
+		$request->setReasons( [
+			$this->config->getTranslatableDescription()->getText(
+				$this->payment->getAmount(),
+				$this->payment->getInterval()
+			),
+			$this->payment->getPaymentReferenceCode()
+		] );
 		$request->setSuccessUrl(
 			$this->config->getReturnUrl() . '?' . http_build_query(
 				[

--- a/src/Domain/PaymentUrlGenerator/SofortConfig.php
+++ b/src/Domain/PaymentUrlGenerator/SofortConfig.php
@@ -6,25 +6,12 @@ namespace WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator;
 
 class SofortConfig {
 
-	private string $reasonText;
-	private string $locale;
-	private string $returnUrl;
-	private string $cancelUrl;
-	private string $notificationUrl;
-	private TranslatableDescription $translatableDescription;
-
-	public function __construct( string $reasonText, string $locale, string $returnUrl, string $cancelUrl, string $notificationUrl,
-		TranslatableDescription $translatableDescription ) {
-		$this->reasonText = $reasonText;
-		$this->locale = $locale;
-		$this->returnUrl = $returnUrl;
-		$this->cancelUrl = $cancelUrl;
-		$this->notificationUrl = $notificationUrl;
-		$this->translatableDescription = $translatableDescription;
-	}
-
-	public function getReasonText(): string {
-		return $this->reasonText;
+	public function __construct(
+		private string $locale,
+		private string $returnUrl,
+		private string $cancelUrl,
+		private string $notificationUrl,
+		private TranslatableDescription $translatableDescription ) {
 	}
 
 	public function getLocale(): string {

--- a/tests/Unit/Domain/PaymentUrlGenerator/SofortTest.php
+++ b/tests/Unit/Domain/PaymentUrlGenerator/SofortTest.php
@@ -32,7 +32,6 @@ class SofortTest extends TestCase {
 		$translatableDescription = $this->createMock( TranslatableDescription::class );
 
 		$config = new SofortUrlConfig(
-			'Donation',
 			$locale,
 			'https://us.org/yes',
 			'https://us.org/no',
@@ -68,7 +67,6 @@ class SofortTest extends TestCase {
 		$expectedUrl = 'https://dn.ht/picklecat/';
 		$translatableDescriptionMock = $this->createMock( TranslatableDescription::class );
 		$config = new SofortUrlConfig(
-			'Donation',
 			'DE',
 			'https://us.org/yes',
 			'https://us.org/no',
@@ -98,7 +96,6 @@ class SofortTest extends TestCase {
 	public function testWhenApiReturnsErrorAnExceptionWithApiErrorMessageIsThrown(): void {
 		$translatableDescriptionStub = $this->createStub( TranslatableDescription::class );
 		$config = new SofortUrlConfig(
-			'Your purchase',
 			'DE',
 			'https://irreleva.nt/y',
 			'https://irreleva.nt/n',


### PR DESCRIPTION
Drop reasonText and use the previously-unused TranslatableDescription instead.
This makes the configuration and URL generator more consistent with the
others.