### PR TITLE
Change display data keys

### DIFF
--- a/src/Domain/Model/BankTransferPayment.php
+++ b/src/Domain/Model/BankTransferPayment.php
@@ -65,7 +65,8 @@ class BankTransferPayment extends Payment implements CancellablePayment {
 
 	public function getDisplayValues(): array {
 		$parentValues = parent::getDisplayValues();
-		$subtypeValues = $this->getPaymentSpecificLegacyData();
+		$paymentReferenceCode = $this->getPaymentReferenceCode();
+		$subtypeValues = $paymentReferenceCode ? [ 'paymentReferenceCode' => $paymentReferenceCode ] : [];
 		return array_merge(
 			$parentValues,
 			$subtypeValues

--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -16,6 +16,12 @@ class SofortPayment extends Payment implements BookablePayment {
 
 	private const PAYMENT_METHOD = 'SUB';
 
+	private const LEGACY_TO_DISPLAY_KEY_MAP = [
+		'transaction_id' => 'transactionId',
+		'valuation_date' => 'valuationDate',
+		'ueb_code' => 'paymentReferenceCode'
+	];
+
 	/**
 	 * This field is nullable to allow for anonymisation
 	 *
@@ -105,7 +111,15 @@ class SofortPayment extends Payment implements BookablePayment {
 
 	public function getDisplayValues(): array {
 		$parentValues = parent::getDisplayValues();
-		$subtypeValues = $this->getPaymentSpecificLegacyData();
+		$legacySubtypeValues = $this->getPaymentSpecificLegacyData();
+		$subtypeValues = [];
+		foreach ( $legacySubtypeValues as $key => $value ) {
+			if ( isset( self::LEGACY_TO_DISPLAY_KEY_MAP[$key] ) ) {
+				$subtypeValues[self::LEGACY_TO_DISPLAY_KEY_MAP[$key]] = $value;
+			} else {
+				$subtypeValues[$key] = $value;
+			}
+		}
 		return array_merge(
 			$parentValues,
 			$subtypeValues

--- a/tests/Unit/Domain/Model/BankTransferPaymentTest.php
+++ b/tests/Unit/Domain/Model/BankTransferPaymentTest.php
@@ -102,7 +102,7 @@ class BankTransferPaymentTest extends TestCase {
 			'amount' => 7821,
 			'interval' => 1,
 			'paymentType' => 'UEB',
-			'ueb_code' => 'XW-TAR-ARA-X'
+			'paymentReferenceCode' => 'XW-TAR-ARA-X'
 		];
 
 		$this->assertEquals( $expectedOutput, $payment->getDisplayValues() );

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -146,9 +146,9 @@ class SofortPaymentTest extends TestCase {
 			'amount' => 1000,
 			'interval' => 0,
 			'paymentType' => 'SUB',
-			'ueb_code' => 'XW-DAR-E99-X',
-			'transaction_id' => 'yellow',
-			'valuation_date' => '2001-12-24 17:30:00'
+			'paymentReferenceCode' => 'XW-DAR-E99-X',
+			'transactionId' => 'yellow',
+			'valuationDate' => '2001-12-24 17:30:00'
 		];
 
 		$this->assertNotNull( $payment->getValuationDate() );


### PR DESCRIPTION
Don't use legacy keys for BankTransferPayment and SofortPayment. The
"ueb_code" key replicated a German database column name, which we use
for legacy reasons but that should not seep into template data (or API
JSON) keys