### PR TITLE
Combine status and type legacy data

### DIFF
--- a/src/Domain/Model/BookingDataTransformers/PayPalBookingTransformer.php
+++ b/src/Domain/Model/BookingDataTransformers/PayPalBookingTransformer.php
@@ -9,6 +9,8 @@ class PayPalBookingTransformer {
 	private const PAYER_ID_KEY = 'payer_id';
 	private const VALUATION_DATE_KEY = 'payment_date';
 	public const TRANSACTION_ID_KEY = 'txn_id';
+	public const TRANSACTION_TYPE_KEY = 'txn_type';
+	public const PAYMENT_STATUS_LEGACY_KEY = 'ext_payment_status';
 
 	/**
 	 * Sent by PayPal in "payment_date" field.
@@ -100,6 +102,11 @@ class PayPalBookingTransformer {
 		foreach ( self::LEGACY_KEY_MAP as $legacyKey => $bookingDataKey ) {
 			$result[$legacyKey] = $this->rawBookingData[$bookingDataKey] ?? '';
 		}
+
+		if ( isset( $result[self::PAYMENT_STATUS_LEGACY_KEY] ) && isset( $this->rawBookingData[self::TRANSACTION_TYPE_KEY] ) ) {
+			$result[self::PAYMENT_STATUS_LEGACY_KEY] = $result[self::PAYMENT_STATUS_LEGACY_KEY] . '/' . $this->rawBookingData[self::TRANSACTION_TYPE_KEY];
+		}
+
 		return $result;
 	}
 

--- a/tests/Data/PayPalPaymentBookingData.php
+++ b/tests/Data/PayPalPaymentBookingData.php
@@ -35,6 +35,7 @@ class PayPalPaymentBookingData {
 			'settle_amount' => '2.70',
 			'subscr_id' => '8RHHUM3W3PRH7QY6B59',
 			'txn_id' => self::TRANSACTION_ID,
+			'txn_type' => 'express_checkout',
 		];
 	}
 
@@ -49,6 +50,6 @@ class PayPalPaymentBookingData {
 	}
 
 	public static function newEncodedValidBookingData(): string {
-		return '{"item_number":"1","mc_currency":"EUR","mc_fee":"2.70","mc_gross":"2.70","payer_email":"foerderpp@wikimedia.de","payer_id":"42","payer_status":"verified","payment_date":"10:54:49 Dec 02, 2012 PST","payment_status":"processed","payment_type":"instant","settle_amount":"2.70","subscr_id":"8RHHUM3W3PRH7QY6B59","txn_id":"T4242"}';
+		return '{"item_number":"1","mc_currency":"EUR","mc_fee":"2.70","mc_gross":"2.70","payer_email":"foerderpp@wikimedia.de","payer_id":"42","payer_status":"verified","payment_date":"10:54:49 Dec 02, 2012 PST","payment_status":"processed","payment_type":"instant","settle_amount":"2.70","subscr_id":"8RHHUM3W3PRH7QY6B59","txn_id":"T4242","txn_type":"express_checkout"}';
 	}
 }

--- a/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
@@ -149,6 +149,7 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 			'settle_amount' => '2.70',
 			'subscr_id' => '8RHHUM3W3PRH7QY6B59',
 			'txn_id' => 'T4242',
+			'txn_type' => 'express_checkout'
 		], $paymentSpy->getBookingData() );
 
 		$this->assertSame( 1, $followupPayment->getLegacyData()->paymentSpecificValues['parent_payment_id'] );

--- a/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
+++ b/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
@@ -94,7 +94,7 @@ class PayPalBookingTransformerTest extends TestCase {
 			'ext_payment_id' => $bookingRequestData['txn_id'],
 			'ext_subscr_id' => $bookingRequestData['subscr_id'],
 			'ext_payment_type' => $bookingRequestData['payment_type'],
-			'ext_payment_status' => $bookingRequestData['payment_status'],
+			'ext_payment_status' => $bookingRequestData['payment_status'] . '/' . $bookingRequestData['txn_type'],
 			'ext_payment_account' => $bookingRequestData['payer_id'],
 			'ext_payment_timestamp' => $bookingRequestData['payment_date'],
 		], $result );

--- a/tests/Unit/Domain/Model/PayPalPaymentTest.php
+++ b/tests/Unit/Domain/Model/PayPalPaymentTest.php
@@ -188,7 +188,7 @@ class PayPalPaymentTest extends TestCase {
 			'ext_payment_id' => 'T4242',
 			'ext_subscr_id' => '8RHHUM3W3PRH7QY6B59',
 			'ext_payment_type' => 'instant',
-			'ext_payment_status' => 'processed',
+			'ext_payment_status' => 'processed/express_checkout',
 			'ext_payment_account' => '42',
 			'ext_payment_timestamp' => PayPalPaymentBookingData::PAYMENT_DATE
 		];


### PR DESCRIPTION
The data export expects the status to be combined with the transaction type in order to see if it was instigated by a donor or is an automatic renewal

Ticket: https://phabricator.wikimedia.org/T307892