### PR TITLE
Add Doctrine Migration for DB schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 
 		"doctrine/orm": "^2.11",
 		"doctrine/dbal": "^3.3",
+		"doctrine/migrations": "^3.5",
 		"sofort/sofortlib-php": "^3.2",
 		"symfony/cache": "^6.0",
 		"guzzlehttp/guzzle": "^7.4"

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.BankTransferPayment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.BankTransferPayment.dcm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment" table="payments_bank_transfer">
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment" table="payment_bank_transfer">
         <one-to-one field="paymentReferenceCode" target-entity="PaymentReferenceCode">
             <join-column name="payment_reference_code" referenced-column-name="code" unique="true"/>
             <cascade>

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.CreditCardPayment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.CreditCardPayment.dcm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment" table="payments_credit_card">
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment" table="payment_credit_card">
         <field name="valuationDate" type="datetime_immutable" column="valuation_date" nullable="true"/>
         <field name="bookingData" type="json" column="booking_data" nullable="true"/>
     </entity>

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.DirectDebitPayment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.DirectDebitPayment.dcm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment" table="payments_direct_debit">
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment" table="payment_direct_debit">
         <field name="iban" type="Iban" column="iban" nullable="true"/>
         <field name="bic" type="string" column="bic" nullable="true"/>
         <field name="isCancelled" type="boolean" column="is_cancelled"/>

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.PayPalPayment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.PayPalPayment.dcm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment" table="payments_paypal">
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment" table="payment_paypal">
         <indexes>
             <index name="ppl_transaction_id" columns="transaction_id"/>
         </indexes>

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.Payment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.Payment.dcm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\Payment" table="payments" inheritance-type="JOINED">
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\Payment" table="payment" inheritance-type="JOINED">
         <discriminator-column name="payment_method" type="string" length="3"/>
         <discriminator-map>
             <discriminator-mapping value="MCP" class="WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment"/>

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.PaymentId.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.PaymentId.dcm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\PaymentId" table="payment_id">
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\PaymentId" table="last_generated_payment_id">
         <id name="id" type="integer" column="id">
             <generator strategy="IDENTITY"/>
         </id>

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.SofortPayment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.SofortPayment.dcm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment" table="payments_sofort">
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment" table="payment_sofort">
         <field name="valuationDate" type="datetime_immutable" column="valuation_date" nullable="true"/>
         <field name="transactionId" column="transaction_id" nullable="true"/>
         <one-to-one field="paymentReferenceCode" target-entity="PaymentReferenceCode">

--- a/src/DataAccess/DoctrinePaymentIdRepository.php
+++ b/src/DataAccess/DoctrinePaymentIdRepository.php
@@ -36,12 +36,12 @@ class DoctrinePaymentIdRepository implements PaymentIdRepository {
 	}
 
 	private function updatePaymentId( Connection $connection ): void {
-		$statement = $connection->prepare( "UPDATE payment_id SET payment_id = payment_id + 1" );
+		$statement = $connection->prepare( "UPDATE last_generated_payment_id SET payment_id = payment_id + 1" );
 		$statement->executeStatement();
 	}
 
 	private function getCurrentIdResult( Connection $connection ): Result {
-		$statement = $connection->prepare( 'SELECT payment_id FROM payment_id LIMIT 1' );
+		$statement = $connection->prepare( 'SELECT payment_id FROM last_generated_payment_id LIMIT 1' );
 		return $statement->executeQuery();
 	}
 }

--- a/src/DataAccess/Migrations/Version20220729162240.php
+++ b/src/DataAccess/Migrations/Version20220729162240.php
@@ -31,7 +31,7 @@ final class Version20220729162240 extends AbstractMigration {
 		$this->verifyDatabasePlatformIsMariaDB();
 
 		$this->addSql( <<<'EOT'
-CREATE TABLE payment_id (
+CREATE TABLE last_generated_payment_id (
     id INT AUTO_INCREMENT NOT NULL, 
     payment_id INT UNSIGNED DEFAULT 0 NOT NULL, 
     PRIMARY KEY(id)
@@ -48,7 +48,7 @@ EOT
 );
 
 		$this->addSql( <<<'EOT'
-CREATE TABLE payments (
+CREATE TABLE payment (
     id INT NOT NULL, 
     amount INT NOT NULL, 
     payment_interval INT NOT NULL, 
@@ -58,7 +58,7 @@ CREATE TABLE payments (
 EOT
 );
 		$this->addSql( <<<'EOT'
-CREATE TABLE payments_bank_transfer (
+CREATE TABLE payment_bank_transfer (
     id INT NOT NULL, 
     payment_reference_code VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
     is_cancelled TINYINT(1) NOT NULL,
@@ -70,7 +70,7 @@ EOT
 );
 
 		$this->addSql( <<<'EOT'
-CREATE TABLE payments_credit_card (
+CREATE TABLE payment_credit_card (
 	id INT NOT NULL,
 	valuation_date DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
 	booking_data LONGTEXT CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci` COMMENT '(DC2Type:json)',
@@ -80,7 +80,7 @@ EOT
 );
 
 		$this->addSql( <<<'EOT'
-CREATE TABLE payments_direct_debit (
+CREATE TABLE payment_direct_debit (
     id INT NOT NULL,
     iban VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
     bic VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
@@ -91,7 +91,7 @@ EOT
 );
 
 		$this->addSql( <<<'EOT'
-CREATE TABLE payments_paypal (
+CREATE TABLE payment_paypal (
 	id INT NOT NULL,
 	parent_payment_id INT DEFAULT NULL,
 	valuation_date DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
@@ -106,7 +106,7 @@ EOT
 );
 
 		$this->addSql( <<<'EOT'
-CREATE TABLE payments_sofort (
+CREATE TABLE payment_sofort (
 	id INT NOT NULL,
 	payment_reference_code VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
 	valuation_date DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
@@ -122,14 +122,14 @@ EOT
 	public function down( Schema $schema ): void {
 		$this->verifyDatabasePlatformIsMariaDB();
 
-		$this->addSql( 'DROP TABLE payment_id' );
+		$this->addSql( 'DROP TABLE last_generated_payment_id' );
 		$this->addSql( 'DROP TABLE payment_reference_codes' );
-		$this->addSql( 'DROP TABLE payments' );
-		$this->addSql( 'DROP TABLE payments_bank_transfer' );
-		$this->addSql( 'DROP TABLE payments_credit_card' );
-		$this->addSql( 'DROP TABLE payments_direct_debit' );
-		$this->addSql( 'DROP TABLE payments_paypal' );
-		$this->addSql( 'DROP TABLE payments_sofort' );
+		$this->addSql( 'DROP TABLE payment' );
+		$this->addSql( 'DROP TABLE payment_bank_transfer' );
+		$this->addSql( 'DROP TABLE payment_credit_card' );
+		$this->addSql( 'DROP TABLE payment_direct_debit' );
+		$this->addSql( 'DROP TABLE payment_paypal' );
+		$this->addSql( 'DROP TABLE payment_sofort' );
 	}
 
 	private function verifyDatabasePlatformIsMariaDB(): void {

--- a/src/DataAccess/Migrations/Version20220729162240.php
+++ b/src/DataAccess/Migrations/Version20220729162240.php
@@ -1,0 +1,141 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\DataAccess\Migrations;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Create payment tables and indexes for the payment domain.
+ *
+ * This migration is part of the "payment refactoring" epic
+ * {@see https://phabricator.wikimedia.org/T192323} which moved
+ * the persistence of payment-related data from the individual bounded contexts
+ * (donations, memberships) into its own bounded context (payment).
+ * This migration creates the persistence tables for the refactored
+ * 'payment' bounded context.
+ *
+ * The genesis of this SQL was as follows:
+ * - We created the domain models (in {@see \WMDE\Fundraising\PaymentContext\Domain\Model\ })
+ * - We created the XML database mappings
+ * - We used a the {@see \Doctrine\ORM\Tools\SchemaTool} class to generate the SQL statements from the mappings
+ */
+final class Version20220729162240 extends AbstractMigration {
+	public function getDescription(): string {
+		return 'Create the payment tables and indexes for the payment.';
+	}
+
+	public function up( Schema $schema ): void {
+		$this->verifyDatabasePlatformIsMariaDB();
+
+		$this->addSql( <<<'EOT'
+CREATE TABLE payment_id (
+    id INT AUTO_INCREMENT NOT NULL, 
+    payment_id INT UNSIGNED DEFAULT 0 NOT NULL, 
+    PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB 
+EOT
+);
+
+		$this->addSql( <<<'EOT'
+CREATE TABLE payment_reference_codes (
+    code VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`, 
+    PRIMARY KEY(code)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB 
+EOT
+);
+
+		$this->addSql( <<<'EOT'
+CREATE TABLE payments (
+    id INT NOT NULL, 
+    amount INT NOT NULL, 
+    payment_interval INT NOT NULL, 
+    payment_method VARCHAR(3) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`, 
+    PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB 
+EOT
+);
+		$this->addSql( <<<'EOT'
+CREATE TABLE payments_bank_transfer (
+    id INT NOT NULL, 
+    payment_reference_code VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
+    is_cancelled TINYINT(1) NOT NULL,
+    
+    UNIQUE INDEX UNIQ_F63CD417E5FE723C (payment_reference_code), 
+    PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB 
+EOT
+);
+
+		$this->addSql( <<<'EOT'
+CREATE TABLE payments_credit_card (
+	id INT NOT NULL,
+	valuation_date DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+	booking_data LONGTEXT CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci` COMMENT '(DC2Type:json)',
+	PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB 
+EOT
+);
+
+		$this->addSql( <<<'EOT'
+CREATE TABLE payments_direct_debit (
+    id INT NOT NULL,
+    iban VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
+    bic VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
+    is_cancelled TINYINT(1) NOT NULL,
+    PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB 
+EOT
+);
+
+		$this->addSql( <<<'EOT'
+CREATE TABLE payments_paypal (
+	id INT NOT NULL,
+	parent_payment_id INT DEFAULT NULL,
+	valuation_date DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+	booking_data LONGTEXT CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci` COMMENT '(DC2Type:json)',
+	transaction_id VARCHAR(36) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
+	
+	INDEX IDX_2A359C3C438027EB (parent_payment_id),
+	INDEX ppl_transaction_id (transaction_id),
+	PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB 
+EOT
+);
+
+		$this->addSql( <<<'EOT'
+CREATE TABLE payments_sofort (
+	id INT NOT NULL,
+	payment_reference_code VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
+	valuation_date DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+	transaction_id VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`,
+	
+	UNIQUE INDEX UNIQ_7E122AB3E5FE723C (payment_reference_code),
+	PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB 
+EOT
+);
+	}
+
+	public function down( Schema $schema ): void {
+		$this->verifyDatabasePlatformIsMariaDB();
+
+		$this->addSql( 'DROP TABLE payment_id' );
+		$this->addSql( 'DROP TABLE payment_reference_codes' );
+		$this->addSql( 'DROP TABLE payments' );
+		$this->addSql( 'DROP TABLE payments_bank_transfer' );
+		$this->addSql( 'DROP TABLE payments_credit_card' );
+		$this->addSql( 'DROP TABLE payments_direct_debit' );
+		$this->addSql( 'DROP TABLE payments_paypal' );
+		$this->addSql( 'DROP TABLE payments_sofort' );
+	}
+
+	private function verifyDatabasePlatformIsMariaDB(): void {
+		$this->abortIf(
+			!$this->connection->getDatabasePlatform() instanceof MariaDBPlatform,
+			"Migration can only be executed safely on MariaDB platform (at least 10.4)."
+		);
+	}
+}

--- a/src/Domain/Model/PaymentId.php
+++ b/src/Domain/Model/PaymentId.php
@@ -6,7 +6,7 @@ namespace WMDE\Fundraising\PaymentContext\Domain\Model;
 
 /**
  * This class and its Doctrine mapping are only used in the test environment to quickly create and
- * tear down the payment_id table. The production environment uses a migration to set up the table.
+ * tear down the last_generated_payment_id table. The production environment uses a migration to set up the table.
  *
  * When setting up a test environment that needs to generate payment IDs in the database,
  * you must insert one PaymentId into the table. The easiest way to accomplish this is to run

--- a/src/Services/TransactionIdFinder/DoctrineTransactionIdFinder.php
+++ b/src/Services/TransactionIdFinder/DoctrineTransactionIdFinder.php
@@ -26,8 +26,8 @@ class DoctrineTransactionIdFinder implements TransactionIdFinder {
 
 		$qb = $this->db->createQueryBuilder();
 		$qb->select( 'ppl.transaction_id', 'p.id' )
-			->from( 'payments', 'p' )
-			->join( 'p', 'payments_paypal', 'ppl', 'ppl.id=p.id' )
+			->from( 'payment', 'p' )
+			->join( 'p', 'payment_paypal', 'ppl', 'ppl.id=p.id' )
 			->where( 'p.id=:paymentId' )
 			->orWhere( 'ppl.parent_payment_id=:paymentId' )
 			->setParameter( 'paymentId', $paymentId );
@@ -50,7 +50,7 @@ class DoctrineTransactionIdFinder implements TransactionIdFinder {
 	public function transactionIdExists( string $transactionId ): bool {
 		$qb = $this->db->createQueryBuilder();
 		$qb->select( 'COUNT(id)' )
-			->from( 'payments_paypal' )
+			->from( 'payment_paypal' )
 			->where( 'transaction_id=:transactionId' )
 			->setParameter( 'transactionId', $transactionId );
 		return $qb->fetchOne() > 0;

--- a/src/UseCases/CreateBookedPayPalPayment/CreateBookedPayPalPaymentUseCase.php
+++ b/src/UseCases/CreateBookedPayPalPayment/CreateBookedPayPalPaymentUseCase.php
@@ -9,8 +9,8 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentIdRepository;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentRepository;
-use WMDE\Fundraising\PaymentContext\Services\ExternalVerificationService\PayPal\PayPalVerificationService;
 use WMDE\Fundraising\PaymentContext\Services\TransactionIdFinder;
+use WMDE\Fundraising\PaymentContext\UseCases\BookPayment\VerificationService;
 
 /**
  * This use case will be used to book incoming PayPal payments without any reference where we can look up a payment ID.
@@ -23,10 +23,10 @@ use WMDE\Fundraising\PaymentContext\Services\TransactionIdFinder;
  */
 class CreateBookedPayPalPaymentUseCase {
 	public function __construct(
-		private PaymentRepository $repository,
-		private PaymentIdRepository $idGenerator,
-		private PayPalVerificationService $verificationService,
-		private TransactionIdFinder $transactionIdFinder
+		private readonly PaymentRepository $repository,
+		private readonly PaymentIdRepository $idGenerator,
+		private readonly VerificationService $verificationService,
+		private readonly TransactionIdFinder $transactionIdFinder
 	) {
 	}
 

--- a/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
@@ -406,8 +406,8 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	private function fetchRawCreditCardPaymentData(): array {
 		$data = $this->connection->createQueryBuilder()
 			->select( 'p.amount', 'p.payment_interval', 'p.payment_method', 'pcc.valuation_date', 'pcc.booking_data' )
-			->from( 'payments', 'p' )
-			->join( 'p', 'payments_credit_card', 'pcc', 'p.id=pcc.id' )
+			->from( 'payment', 'p' )
+			->join( 'p', 'payment_credit_card', 'pcc', 'p.id=pcc.id' )
 			->where( 'p.id=1' )
 			->fetchAssociative();
 		if ( $data === false ) {
@@ -417,13 +417,13 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	}
 
 	private function insertRawBookedCreditCardData(): void {
-		$this->connection->insert( 'payments', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'MCP' ] );
-		$this->connection->insert( 'payments_credit_card', [ 'id' => 1, 'valuation_date' => '2021-12-24 23:00:00', 'booking_data' => '{"transactionId":"1eetcaffee"}' ] );
+		$this->connection->insert( 'payment', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'MCP' ] );
+		$this->connection->insert( 'payment_credit_card', [ 'id' => 1, 'valuation_date' => '2021-12-24 23:00:00', 'booking_data' => '{"transactionId":"1eetcaffee"}' ] );
 	}
 
 	private function insertRawUnBookedCreditCardData(): void {
-		$this->connection->insert( 'payments', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'MCP' ] );
-		$this->connection->insert( 'payments_credit_card', [ 'id' => 1, 'valuation_date' => null, 'booking_data' => null ] );
+		$this->connection->insert( 'payment', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'MCP' ] );
+		$this->connection->insert( 'payment_credit_card', [ 'id' => 1, 'valuation_date' => null, 'booking_data' => null ] );
 	}
 
 	/**
@@ -434,8 +434,8 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	private function fetchRawPayPalPaymentData( int $paymentId = 1 ): array {
 		$data = $this->connection->createQueryBuilder()
 			->select( 'p.amount', 'p.payment_interval', 'p.payment_method', 'ppp.valuation_date', 'ppp.booking_data', 'ppp.parent_payment_id' )
-			->from( 'payments', 'p' )
-			->join( 'p', 'payments_paypal', 'ppp', 'p.id=ppp.id' )
+			->from( 'payment', 'p' )
+			->join( 'p', 'payment_paypal', 'ppp', 'p.id=ppp.id' )
 			->where( 'p.id=:paymentId' )
 			->setParameter( 'paymentId', $paymentId )
 			->fetchAssociative();
@@ -446,14 +446,14 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	}
 
 	private function insertRawPayPalData(): void {
-		$this->connection->insert( 'payments', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'PPL' ] );
-		$this->connection->insert( 'payments', [ 'id' => 2, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'PPL' ] );
-		$this->connection->insert( 'payments_paypal', [
+		$this->connection->insert( 'payment', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'PPL' ] );
+		$this->connection->insert( 'payment', [ 'id' => 2, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'PPL' ] );
+		$this->connection->insert( 'payment_paypal', [
 			'id' => 1,
 			'valuation_date' => '2021-12-24 23:00:00',
 			'booking_data' => PayPalPaymentBookingData::newEncodedValidBookingData()
 		] );
-		$this->connection->insert( 'payments_paypal', [
+		$this->connection->insert( 'payment_paypal', [
 			'id' => 2,
 			'valuation_date' => '2022-12-24 23:00:00',
 			'booking_data' => PayPalPaymentBookingData::newEncodedValidBookingData(),
@@ -468,8 +468,8 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	private function fetchRawBankTransferPaymentData(): array {
 		$data = $this->connection->createQueryBuilder()
 			->select( 'p.amount', 'p.payment_interval', 'p.payment_method', 'prc.code AS payment_reference_code' )
-			->from( 'payments', 'p' )
-			->leftJoin( 'p', 'payments_bank_transfer', 'pbt', 'p.id=pbt.id' )
+			->from( 'payment', 'p' )
+			->leftJoin( 'p', 'payment_bank_transfer', 'pbt', 'p.id=pbt.id' )
 			->leftJoin( 'pbt', 'payment_reference_codes', 'prc', 'pbt.payment_reference_code=prc.code' )
 			->where( 'p.id=1' )
 			->fetchAssociative();
@@ -481,13 +481,13 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 
 	private function insertRawBankTransferData(): void {
 		$this->connection->insert( 'payment_reference_codes', [ 'code' => 'XW-RAA-RR4-Y' ] );
-		$this->connection->insert( 'payments', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'UEB' ] );
-		$this->connection->insert( 'payments_bank_transfer', [ 'id' => 1, 'payment_reference_code' => 'XW-RAA-RR4-Y', 'is_cancelled' => 0 ] );
+		$this->connection->insert( 'payment', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'UEB' ] );
+		$this->connection->insert( 'payment_bank_transfer', [ 'id' => 1, 'payment_reference_code' => 'XW-RAA-RR4-Y', 'is_cancelled' => 0 ] );
 	}
 
 	private function insertRawAnonymisedBankTransferData(): void {
-		$this->connection->insert( 'payments', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'UEB' ] );
-		$this->connection->insert( 'payments_bank_transfer', [ 'id' => 1, 'payment_reference_code' => null, 'is_cancelled' => 0 ] );
+		$this->connection->insert( 'payment', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'UEB' ] );
+		$this->connection->insert( 'payment_bank_transfer', [ 'id' => 1, 'payment_reference_code' => null, 'is_cancelled' => 0 ] );
 	}
 
 	/**
@@ -497,16 +497,16 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	 * @throws \Doctrine\DBAL\Exception
 	 */
 	private function insertRawDirectDebitPaymentData( array $extraData = [] ): void {
-		$this->connection->insert( 'payments', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'BEZ' ] );
-		$this->connection->insert( 'payments_direct_debit', array_merge(
+		$this->connection->insert( 'payment', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'BEZ' ] );
+		$this->connection->insert( 'payment_direct_debit', array_merge(
 			[ 'id' => 1, 'iban' => self::IBAN, 'bic' => self::BIC, 'is_cancelled' => 0 ],
 			$extraData
 		) );
 	}
 
 	private function insertRawAnonymisedDirectDebitPaymentData(): void {
-		$this->connection->insert( 'payments', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'BEZ' ] );
-		$this->connection->insert( 'payments_direct_debit', [ 'id' => 1, 'iban' => null, 'bic' => null, 'is_cancelled' => 0 ] );
+		$this->connection->insert( 'payment', [ 'id' => 1, 'amount' => '4223', 'payment_interval' => 12, 'payment_method' => 'BEZ' ] );
+		$this->connection->insert( 'payment_direct_debit', [ 'id' => 1, 'iban' => null, 'bic' => null, 'is_cancelled' => 0 ] );
 	}
 
 	/**
@@ -516,8 +516,8 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	private function fetchRawDirectDebitPaymentData(): array {
 		$data = $this->connection->createQueryBuilder()
 			->select( 'p.amount', 'p.payment_interval', 'p.payment_method', 'pdd.iban', 'pdd.bic', 'pdd.is_cancelled' )
-			->from( 'payments', 'p' )
-			->join( 'p', 'payments_direct_debit', 'pdd', 'p.id=pdd.id' )
+			->from( 'payment', 'p' )
+			->join( 'p', 'payment_direct_debit', 'pdd', 'p.id=pdd.id' )
 			->where( 'p.id=1' )
 			->fetchAssociative();
 		if ( $data === false ) {
@@ -540,8 +540,8 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 				'psub.transaction_id',
 				'prc.code AS payment_reference_code'
 			)
-			->from( 'payments', 'p' )
-			->leftJoin( 'p', 'payments_sofort', 'psub', 'p.id=psub.id' )
+			->from( 'payment', 'p' )
+			->leftJoin( 'p', 'payment_sofort', 'psub', 'p.id=psub.id' )
 			->leftJoin( 'psub', 'payment_reference_codes', 'prc', 'psub.payment_reference_code=prc.code' )
 			->where( 'p.id=42' )
 			->fetchAssociative();
@@ -553,13 +553,13 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 
 	private function insertRawSofortData(): void {
 		$this->connection->insert( 'payment_reference_codes', [ 'code' => 'XW-TAR-ARA-Y' ] );
-		$this->connection->insert( 'payments', [
+		$this->connection->insert( 'payment', [
 			'id' => 42,
 			'amount' => '1233',
 			'payment_interval' => 0,
 			'payment_method' => 'SUB'
 		] );
-		$this->connection->insert( 'payments_sofort', [
+		$this->connection->insert( 'payment_sofort', [
 			'id' => 42,
 			'valuation_date' => '2021-06-24 23:00:00',
 			'transaction_id' => 'imatransID42',
@@ -568,13 +568,13 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	}
 
 	private function insertRawAnonymisedSofortData(): void {
-		$this->connection->insert( 'payments', [
+		$this->connection->insert( 'payment', [
 			'id' => 42,
 			'amount' => '1233',
 			'payment_interval' => 0,
 			'payment_method' => 'SUB'
 		] );
-		$this->connection->insert( 'payments_sofort', [
+		$this->connection->insert( 'payment_sofort', [
 			'id' => 42,
 			'valuation_date' => '2021-06-24 23:00:00',
 			'transaction_id' => 'imatransID42',


### PR DESCRIPTION
Autogenerated the migration with `doctrine-migrations dump-schema`,
since these tables are new. Using raw SQL instead of the `Schema` object
API is OK, because trying to build the schema "from scratch" would be
error-prone.

Added doctrine-migrations as a dependency.

This is for https://phabricator.wikimedia.org/T309018