### PR TITLE
Change legacy status of booked Sofort payments

### DIFF
--- a/src/Domain/Model/LegacyBookingStatusTrait.php
+++ b/src/Domain/Model/LegacyBookingStatusTrait.php
@@ -9,7 +9,8 @@ trait LegacyBookingStatusTrait {
 	abstract public function isBooked(): bool;
 
 	protected function getLegacyPaymentStatus(): string {
-		if ( $this->isBooked() ) { return LegacyPaymentStatus::EXTERNAL_BOOKED->value;
+		if ( $this->isBooked() ) {
+			return LegacyPaymentStatus::EXTERNAL_BOOKED->value;
 		}
 		return LegacyPaymentStatus::EXTERNAL_INCOMPLETE->value;
 	}

--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -105,6 +105,19 @@ class SofortPayment extends Payment implements BookablePayment {
 		return $data;
 	}
 
+	/**
+	 * We override the behavior of the LegacyBookingStatusTrait because Sofort payments need
+	 * to look like bank transfer statements when they are exported.
+	 *
+	 * @return string
+	 */
+	protected function getLegacyPaymentStatus(): string {
+		if ( $this->isBooked() ) {
+			return LegacyPaymentStatus::BANK_TRANSFER->value;
+		}
+		return LegacyPaymentStatus::EXTERNAL_INCOMPLETE->value;
+	}
+
 	public function anonymise(): void {
 		$this->paymentReferenceCode = null;
 	}

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -135,7 +135,7 @@ class SofortPaymentTest extends TestCase {
 		$bookedSofortPayment->bookPayment( $this->makeValidTransactionData(), new DummyPaymentIdRepository() );
 
 		$this->assertSame( LegacyPaymentStatus::EXTERNAL_INCOMPLETE->value, $sofortPayment->getLegacyData()->paymentStatus );
-		$this->assertSame( LegacyPaymentStatus::EXTERNAL_BOOKED->value, $bookedSofortPayment->getLegacyData()->paymentStatus );
+		$this->assertSame( LegacyPaymentStatus::BANK_TRANSFER->value, $bookedSofortPayment->getLegacyData()->paymentStatus );
 	}
 
 	public function testGetDisplayDataReturnsAllFieldsToDisplay(): void {


### PR DESCRIPTION
The importer of our data warehousing wants to treat Sofort payments like
bank transfer payments and apparently checks the status for that :(

This change replicates code that previously was in the donation bounded
context `DomainToLegacyConverter` class.

This is a follow-up PR for https://phabricator.wikimedia.org/T314409

This will also affect the ticket
https://phabricator.wikimedia.org/T312074 in the future
