### PR TITLE
Add restore to cancellable payments

### DIFF
--- a/src/Domain/Model/BankTransferPayment.php
+++ b/src/Domain/Model/BankTransferPayment.php
@@ -59,8 +59,16 @@ class BankTransferPayment extends Payment implements CancellablePayment {
 		$this->isCancelled = true;
 	}
 
+	public function restore(): void {
+		$this->isCancelled = false;
+	}
+
 	public function isCancellable(): bool {
 		return !$this->isCancelled();
+	}
+
+	public function isRestorable(): bool {
+		return $this->isCancelled();
 	}
 
 	public function getDisplayValues(): array {

--- a/src/Domain/Model/CancellablePayment.php
+++ b/src/Domain/Model/CancellablePayment.php
@@ -8,5 +8,9 @@ interface CancellablePayment {
 
 	public function isCancellable(): bool;
 
+	public function isRestorable(): bool;
+
 	public function cancel(): void;
+
+	public function restore(): void;
 }

--- a/src/Domain/Model/DirectDebitPayment.php
+++ b/src/Domain/Model/DirectDebitPayment.php
@@ -66,8 +66,16 @@ class DirectDebitPayment extends Payment implements CancellablePayment {
 		$this->isCancelled = true;
 	}
 
+	public function restore(): void {
+		$this->isCancelled = false;
+	}
+
 	public function isCancellable(): bool {
 		return !$this->isCancelled();
+	}
+
+	public function isRestorable(): bool {
+		return $this->isCancelled();
 	}
 
 	public function getDisplayValues(): array {

--- a/src/UseCases/CancelPayment/CancelPaymentUseCase.php
+++ b/src/UseCases/CancelPayment/CancelPaymentUseCase.php
@@ -32,4 +32,21 @@ class CancelPaymentUseCase {
 
 		return new SuccessResponse();
 	}
+
+	public function restorePayment( int $paymentId ): SuccessResponse|FailureResponse {
+		try {
+			$payment = $this->repository->getPaymentById( $paymentId );
+		} catch ( PaymentNotFoundException $e ) {
+			return new FailureResponse( $e->getMessage() );
+		}
+
+		if ( !( $payment instanceof CancellablePayment ) || !$payment->isRestorable() ) {
+			return new FailureResponse( 'This payment can\'t be restored - it is not cancelled or does not support cancellation' );
+		}
+
+		$payment->restore();
+		$this->repository->storePayment( $payment );
+
+		return new SuccessResponse();
+	}
 }

--- a/tests/Unit/Domain/Model/BankTransferPaymentTest.php
+++ b/tests/Unit/Domain/Model/BankTransferPaymentTest.php
@@ -81,6 +81,15 @@ class BankTransferPaymentTest extends TestCase {
 		$this->assertFalse( $payment->isCancellable() );
 	}
 
+	public function testRestorePayment(): void {
+		$payment = $this->makeCancelledBankTransferPayment();
+
+		$payment->restore();
+
+		$this->assertFalse( $payment->isRestorable() );
+		$this->assertFalse( $payment->isCancelled() );
+	}
+
 	private function makeBankTransferPayment(): BankTransferPayment {
 		return BankTransferPayment::create(
 			1,
@@ -88,6 +97,12 @@ class BankTransferPaymentTest extends TestCase {
 			PaymentInterval::Monthly,
 			new PaymentReferenceCode( 'XW', 'TARARA', 'X' )
 		);
+	}
+
+	private function makeCancelledBankTransferPayment(): BankTransferPayment {
+		$payment = $this->makeBankTransferPayment();
+		$payment->cancel();
+		return $payment;
 	}
 
 	public function testGetDisplayDataReturnsAllFieldsToDisplay(): void {

--- a/tests/Unit/Domain/Model/DirectDebitPaymentTest.php
+++ b/tests/Unit/Domain/Model/DirectDebitPaymentTest.php
@@ -32,6 +32,15 @@ class DirectDebitPaymentTest extends TestCase {
 		$this->assertFalse( $payment->isCancellable() );
 	}
 
+	public function testRestorePayment(): void {
+		$payment = $this->makeCancelledDirectDebitPayment();
+
+		$payment->restore();
+
+		$this->assertFalse( $payment->isCancelled() );
+		$this->assertFalse( $payment->isRestorable() );
+	}
+
 	public function testNewPaymentCanReturnIbanAndBic(): void {
 		$iban = new Iban( DirectDebitBankData::IBAN );
 		$payment = DirectDebitPayment::create(
@@ -104,5 +113,11 @@ class DirectDebitPaymentTest extends TestCase {
 			new Iban( DirectDebitBankData::IBAN ),
 			DirectDebitBankData::BIC
 		);
+	}
+
+	private function makeCancelledDirectDebitPayment(): DirectDebitPayment {
+		$payment = $this->makeDirectDebitPayment();
+		$payment->cancel();
+		return $payment;
 	}
 }


### PR DESCRIPTION
The backend moderators need to be able to restore
a payment that was cancelled by accident.

Ticket: https://phabricator.wikimedia.org/T318217