### PR TITLE
Add confirmation status to cancel success

### DIFF
--- a/src/UseCases/CancelPayment/CancelPaymentUseCase.php
+++ b/src/UseCases/CancelPayment/CancelPaymentUseCase.php
@@ -30,7 +30,7 @@ class CancelPaymentUseCase {
 		$payment->cancel();
 		$this->repository->storePayment( $payment );
 
-		return new SuccessResponse();
+		return new SuccessResponse( $payment->isCompleted() );
 	}
 
 	public function restorePayment( int $paymentId ): SuccessResponse|FailureResponse {
@@ -47,6 +47,6 @@ class CancelPaymentUseCase {
 		$payment->restore();
 		$this->repository->storePayment( $payment );
 
-		return new SuccessResponse();
+		return new SuccessResponse( $payment->isCompleted() );
 	}
 }

--- a/src/UseCases/CancelPayment/SuccessResponse.php
+++ b/src/UseCases/CancelPayment/SuccessResponse.php
@@ -5,5 +5,8 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\PaymentContext\UseCases\CancelPayment;
 
 class SuccessResponse {
-
+	public function __construct(
+		public readonly bool $paymentIsCompleted
+	) {
+	}
 }

--- a/tests/Unit/UseCases/CancelPayment/CancelPaymentUseCaseTest.php
+++ b/tests/Unit/UseCases/CancelPayment/CancelPaymentUseCaseTest.php
@@ -38,6 +38,7 @@ class CancelPaymentUseCaseTest extends TestCase {
 
 		$this->assertTrue( $payment->isCancelled() );
 		$this->assertInstanceOf( SuccessResponse::class, $response );
+		$this->assertTrue( $response->paymentIsCompleted );
 	}
 
 	public function testCancelCanceledPaymentReturnsFailureResponse(): void {
@@ -63,6 +64,7 @@ class CancelPaymentUseCaseTest extends TestCase {
 
 		$this->assertFalse( $payment->isCancelled() );
 		$this->assertInstanceOf( SuccessResponse::class, $response );
+		$this->assertTrue( $response->paymentIsCompleted );
 	}
 
 	public function testRestoreUncanceledPaymentReturnsFailureResponse(): void {


### PR DESCRIPTION
The membership context needs to know if the payment was completed in order to set it's own status so
pass it back in the response.

Ticket: https://phabricator.wikimedia.org/T318217