### PR TITLE
Add paymentWasAlreadyBooked to FailureResponse

### DIFF
--- a/src/UseCases/BookPayment/BookPaymentUseCase.php
+++ b/src/UseCases/BookPayment/BookPaymentUseCase.php
@@ -41,7 +41,7 @@ class BookPaymentUseCase {
 		}
 
 		if ( $this->paymentWasAlreadyBooked( $payment, $transactionData ) ) {
-			return new FailureResponse( 'Payment is already completed' );
+			return FailureResponse::newAlreadyCompletedResponse();
 		}
 
 		$verificationResponse = $this->validateWithExternalService( $payment, $transactionData );

--- a/src/UseCases/BookPayment/FailureResponse.php
+++ b/src/UseCases/BookPayment/FailureResponse.php
@@ -5,8 +5,19 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\PaymentContext\UseCases\BookPayment;
 
 class FailureResponse {
+
+	private const ALREADY_COMPLETED = 'Payment is already completed';
+
 	public function __construct(
 		public readonly string $message
 	) {
+	}
+
+	public static function newAlreadyCompletedResponse(): self {
+		return new self( self::ALREADY_COMPLETED );
+	}
+
+	public function paymentWasAlreadyCompleted(): bool {
+		return $this->message === self::ALREADY_COMPLETED;
 	}
 }

--- a/tests/Unit/UseCases/BookPayment/FailureResponseTest.php
+++ b/tests/Unit/UseCases/BookPayment/FailureResponseTest.php
@@ -1,0 +1,24 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Unit\UseCases\BookPayment;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\UseCases\BookPayment\FailureResponse;
+
+/**
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\BookPayment\FailureResponse
+ */
+class FailureResponseTest extends TestCase {
+	public function testWhenUsingAlreadyCompletedConstructor_isAlreadyCompletedReturnsTrue(): void {
+		$response = FailureResponse::newAlreadyCompletedResponse();
+
+		$this->assertTrue( $response->paymentWasAlreadyCompleted() );
+	}
+
+	public function testWhenStringConstructor_isAlreadyCompletedReturnsFalse(): void {
+		$response = new FailureResponse( 'Could not book payment for ... reasons.' );
+
+		$this->assertFalse( $response->paymentWasAlreadyCompleted() );
+	}
+}


### PR DESCRIPTION
Add a new static constructor and a boolean getter to check if the FailureResponse is caused by an already booked payment. This will help upstream code to check against this condition without using hard-coded string messages (that might change).

Ticket: https://phabricator.wikimedia.org/T321346