### PR TITLE
Ignore memo field in PayPal requests

### DIFF
--- a/src/Domain/Model/BookingDataTransformers/PayPalBookingTransformer.php
+++ b/src/Domain/Model/BookingDataTransformers/PayPalBookingTransformer.php
@@ -41,6 +41,7 @@ class PayPalBookingTransformer {
 		'payer_email',
 		'payer_business_name',
 		'residence_country',
+		'memo',
 	];
 
 	private const LEGACY_KEY_MAP = [

--- a/tests/Data/PayPalPaymentBookingData.php
+++ b/tests/Data/PayPalPaymentBookingData.php
@@ -38,6 +38,7 @@ class PayPalPaymentBookingData {
 			'subscr_id' => '8RHHUM3W3PRH7QY6B59',
 			'txn_id' => self::TRANSACTION_ID,
 			'txn_type' => 'express_checkout',
+			'memo' => 'Liebe Grüße aus Chicago, ich lese euch öfters und werde das nicht ändern.'
 		];
 	}
 

--- a/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
+++ b/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
@@ -27,6 +27,7 @@ class PayPalBookingTransformerTest extends TestCase {
 		$this->assertArrayNotHasKey( 'payer_email', $bookingData );
 		$this->assertArrayNotHasKey( 'payer_business_name', $bookingData );
 		$this->assertArrayNotHasKey( 'residence_country', $bookingData );
+		$this->assertArrayNotHasKey( 'memo', $bookingData );
 	}
 
 	/**


### PR DESCRIPTION
The 'memo' field gets populated when someone sends a PayPal donation to spenden@wikimedia.de without using the donation form. They can enter free-form text on the PayPal page, which will get sent to us in windows-1252 encoding.

This a followup for #123

Ticket: https://phabricator.wikimedia.org/T319386