### PR TITLE
Prepare for PHP 8.2

### DIFF
--- a/src/DataAccess/DoctrinePaymentIdRepository.php
+++ b/src/DataAccess/DoctrinePaymentIdRepository.php
@@ -20,7 +20,7 @@ class DoctrinePaymentIdRepository implements PaymentIdRepository {
 	public function getNewId(): int {
 		$connection = $this->entityManager->getConnection();
 
-		$paymentId = $connection->transactional( function ( Connection $connection ): int {
+		$paymentId = $connection->transactional( function ( Connection $connection ): mixed {
 			$this->updatePaymentId( $connection );
 			$result = $this->getCurrentIdResult( $connection );
 			$id = $result->fetchOne();
@@ -29,10 +29,10 @@ class DoctrinePaymentIdRepository implements PaymentIdRepository {
 				throw new \RuntimeException( 'The ID generator needs a row with initial payment_id set to 0.' );
 			}
 
-			return intval( $id );
+			return $id;
 		} );
 
-		return intval( $paymentId );
+		return ScalarTypeConverter::toInt( $paymentId );
 	}
 
 	private function updatePaymentId( Connection $connection ): void {

--- a/src/DataAccess/DoctrineTypes/Euro.php
+++ b/src/DataAccess/DoctrineTypes/Euro.php
@@ -7,6 +7,7 @@ namespace WMDE\Fundraising\PaymentContext\DataAccess\DoctrineTypes;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use WMDE\Euro\Euro as WMDEEuro;
+use WMDE\Fundraising\PaymentContext\DataAccess\ScalarTypeConverter;
 
 class Euro extends Type {
 
@@ -23,7 +24,7 @@ class Euro extends Type {
 	}
 
 	public function convertToPHPValue( mixed $value, AbstractPlatform $platform ): WMDEEuro {
-		return WMDEEuro::newFromCents( intval( $value ) );
+		return WMDEEuro::newFromCents( ScalarTypeConverter::toInt( $value ) );
 	}
 
 	public function convertToDatabaseValue( mixed $value, AbstractPlatform $platform ): int {

--- a/src/DataAccess/DoctrineTypes/Iban.php
+++ b/src/DataAccess/DoctrineTypes/Iban.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\PaymentContext\DataAccess\DoctrineTypes;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use WMDE\Fundraising\PaymentContext\DataAccess\ScalarTypeConverter;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban as WMDEIban;
 
 class Iban extends Type {
@@ -26,8 +27,7 @@ class Iban extends Type {
 		if ( $value === null ) {
 			return null;
 		}
-
-		return new WMDEIban( strval( $value ) );
+		return new WMDEIban( ScalarTypeConverter::toString( $value ) );
 	}
 
 	public function convertToDatabaseValue( mixed $value, AbstractPlatform $platform ): ?string {

--- a/src/DataAccess/DoctrineTypes/PaymentInterval.php
+++ b/src/DataAccess/DoctrineTypes/PaymentInterval.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\PaymentContext\DataAccess\DoctrineTypes;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use WMDE\Fundraising\PaymentContext\DataAccess\ScalarTypeConverter;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval as DomainPaymentInterval;
 
 class PaymentInterval extends Type {
@@ -23,7 +24,7 @@ class PaymentInterval extends Type {
 	}
 
 	public function convertToPHPValue( mixed $value, AbstractPlatform $platform ): DomainPaymentInterval {
-		return DomainPaymentInterval::from( intval( $value ) );
+		return DomainPaymentInterval::from( ScalarTypeConverter::toInt( $value ) );
 	}
 
 	public function convertToDatabaseValue( mixed $value, AbstractPlatform $platform ): int {

--- a/src/DataAccess/ScalarTypeConverter.php
+++ b/src/DataAccess/ScalarTypeConverter.php
@@ -1,0 +1,28 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\DataAccess;
+
+/**
+ * This class circumvents problems coming from Doctrine database results that by their very nature have to be
+ * of type "mixed", which trips up static analysis tools when calling intval and strval
+ * (because calling them with objects will generate a warning).
+ *
+ * @internal This should only be used inside the DataAccess namespace.
+ */
+class ScalarTypeConverter {
+	public static function toInt( mixed $value ): int {
+		return intval( self::assertScalarType( $value ) );
+	}
+
+	public static function toString( mixed $value ): string {
+		return strval( self::assertScalarType( $value ) );
+	}
+
+	private static function assertScalarType( mixed $value ): int|string|bool|float {
+		if ( is_scalar( $value ) ) {
+			return $value;
+		}
+		throw new \InvalidArgumentException( "Given value is not a scalar type" );
+	}
+}

--- a/src/Domain/Model/BookablePayment.php
+++ b/src/Domain/Model/BookablePayment.php
@@ -13,7 +13,7 @@ interface BookablePayment {
 	 *
 	 * Implementations MUST check if $transactionData has the right shape.
 	 *
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 * @param PaymentIdRepository $idGenerator ID generator in case the booking triggers a followup payment
 	 *
 	 * @return Payment Might be the same payment instance or a different payment in case of followup payments
@@ -26,7 +26,7 @@ interface BookablePayment {
 	public function getValuationDate(): ?DateTimeImmutable;
 
 	/**
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 * @return bool
 	 */
 	public function canBeBooked( array $transactionData ): bool;

--- a/src/Domain/Model/BookingDataTransformers/CreditCardBookingTransformer.php
+++ b/src/Domain/Model/BookingDataTransformers/CreditCardBookingTransformer.php
@@ -24,14 +24,14 @@ class CreditCardBookingTransformer {
 	];
 
 	/**
-	 * @var array<string, mixed>
+	 * @var array<string, scalar>
 	 */
 	private array $rawBookingData;
 
 	private \DateTimeImmutable $valuationDate;
 
 	/**
-	 * @param array<string, mixed> $rawBookingData
+	 * @param array<string, scalar> $rawBookingData
 	 * @param \DateTimeImmutable|null $valuationDate
 	 */
 	public function __construct( array $rawBookingData, ?\DateTimeImmutable $valuationDate = null ) {
@@ -64,7 +64,7 @@ class CreditCardBookingTransformer {
 	}
 
 	/**
-	 * @param array<string, mixed> $rawBookingData
+	 * @param array<string, scalar> $rawBookingData
 	 *
 	 * @return void
 	 */

--- a/src/Domain/Model/BookingDataTransformers/PayPalBookingTransformer.php
+++ b/src/Domain/Model/BookingDataTransformers/PayPalBookingTransformer.php
@@ -61,7 +61,7 @@ class PayPalBookingTransformer {
 	];
 
 	/**
-	 * @var array<string,mixed>
+	 * @var array<string,scalar>
 	 */
 	private array $rawBookingData;
 
@@ -70,7 +70,7 @@ class PayPalBookingTransformer {
 	private \DateTimeImmutable $valuationDate;
 
 	/**
-	 * @param array<string,mixed> $rawBookingData
+	 * @param array<string,scalar> $rawBookingData
 	 */
 	public function __construct( array $rawBookingData ) {
 		if ( empty( $rawBookingData[self::PAYER_ID_KEY] ) ) {
@@ -109,7 +109,7 @@ class PayPalBookingTransformer {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array<string,scalar>
 	 */
 	public function getLegacyData(): array {
 		$result = [];
@@ -125,9 +125,9 @@ class PayPalBookingTransformer {
 	}
 
 	/**
-	 * @param array<string,mixed> $rawBookingData
+	 * @param array<string,scalar> $rawBookingData
 	 *
-	 * @return array<string,mixed>
+	 * @return array<string,scalar>
 	 */
 	private function anonymise( array $rawBookingData ): array {
 		return array_diff_key( $rawBookingData, array_flip( self::KEYS_TO_FILTER ) );

--- a/src/Domain/Model/PayPalPayment.php
+++ b/src/Domain/Model/PayPalPayment.php
@@ -49,7 +49,7 @@ class PayPalPayment extends Payment implements BookablePayment {
 	}
 
 	/**
-	 * @param array<string,mixed> $transactionData Payment information from PayPal
+	 * @param array<string,scalar> $transactionData Payment information from PayPal
 	 * @param PaymentIdRepository $idGenerator Used for creating followup payments
 	 *
 	 * @return PayPalPayment
@@ -93,7 +93,7 @@ class PayPalPayment extends Payment implements BookablePayment {
 	/**
 	 * Create a booked followup payment
 	 *
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 * @param PaymentIdRepository $idGenerator
 	 *
 	 * @return PayPalPayment

--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -65,7 +65,7 @@ class SofortPayment extends Payment implements BookablePayment {
 	}
 
 	/**
-	 * @param array<string,mixed> $transactionData Data from the payment provider
+	 * @param array<string,scalar> $transactionData Data from the payment provider
 	 * @param PaymentIdRepository $idGenerator Not used here since we don't have followup payments
 	 *
 	 * @return Payment

--- a/src/Services/KontoCheck/KontoCheckBankDataGenerator.php
+++ b/src/Services/KontoCheck/KontoCheckBankDataGenerator.php
@@ -80,7 +80,15 @@ class KontoCheckBankDataGenerator implements BankDataGenerator {
 	}
 
 	private function bankNameFromBankCode( string $bankCode ): string {
-		return utf8_encode( \lut_name( $bankCode ) ?: '' );
+		$bankName = mb_convert_encoding( \lut_name( $bankCode ) ?: '', 'UTF-8', 'ISO-8859-1' );
+		if ( is_string( $bankName ) ) {
+			return $bankName;
+		} elseif ( $bankName === false ) {
+			// This should never happen
+			throw new \UnexpectedValueException( "lut_name( $bankCode ) returned bank name that could not be transformed from ISO-8859-1 to UTF-8" );
+		}
+		// This return statement would only be reached if mb_convert_encoding was called with an array and is only here to make the method type-safe
+		return '';
 	}
 
 	/**

--- a/src/Services/TransactionIdFinder/DoctrineTransactionIdFinder.php
+++ b/src/Services/TransactionIdFinder/DoctrineTransactionIdFinder.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace WMDE\Fundraising\PaymentContext\Services\TransactionIdFinder;
 
 use Doctrine\DBAL\Connection;
+use WMDE\Fundraising\PaymentContext\DataAccess\ScalarTypeConverter;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Payment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
@@ -42,7 +43,7 @@ class DoctrineTransactionIdFinder implements TransactionIdFinder {
 	private function convertMixedTypes( array $dbResult ): array {
 		$transactionIds = [];
 		foreach ( $dbResult as $transactionId => $paymentId ) {
-			$transactionIds[strval( $transactionId )] = intval( $paymentId );
+			$transactionIds[ScalarTypeConverter::toString( $transactionId )] = ScalarTypeConverter::toInt( $paymentId );
 		}
 		return $transactionIds;
 	}

--- a/src/UseCases/BookPayment/BookPaymentUseCase.php
+++ b/src/UseCases/BookPayment/BookPaymentUseCase.php
@@ -25,7 +25,7 @@ class BookPaymentUseCase {
 
 	/**
 	 * @param int $paymentId
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 *
 	 * @return SuccessResponse|FailureResponse
 	 */
@@ -66,7 +66,7 @@ class BookPaymentUseCase {
 
 	/**
 	 * @param Payment $payment
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 *
 	 * @return VerificationResponse
 	 */
@@ -77,7 +77,7 @@ class BookPaymentUseCase {
 
 	/**
 	 * @param BookablePayment $payment
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 * @return bool
 	 */
 	private function paymentWasAlreadyBooked( BookablePayment $payment, array $transactionData ): bool {
@@ -91,7 +91,7 @@ class BookPaymentUseCase {
 
 	/**
 	 * @param PayPalPayment $payment
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 * @return bool
 	 */
 	private function paypalPaymentWasAlreadyBooked( PayPalPayment $payment, array $transactionData ): bool {

--- a/src/UseCases/CreateBookedPayPalPayment/CreateBookedPayPalPaymentUseCase.php
+++ b/src/UseCases/CreateBookedPayPalPayment/CreateBookedPayPalPaymentUseCase.php
@@ -32,7 +32,7 @@ class CreateBookedPayPalPaymentUseCase {
 
 	/**
 	 * @param int $amountInCents
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 * @return SuccessResponse|FailureResponse
 	 */
 	public function bookNewPayment( int $amountInCents, array $transactionData ): SuccessResponse|FailureResponse {
@@ -62,7 +62,7 @@ class CreateBookedPayPalPaymentUseCase {
 	}
 
 	/**
-	 * @param array<string,mixed> $transactionData
+	 * @param array<string,scalar> $transactionData
 	 * @return bool
 	 */
 	private function transactionWasAlreadyProcessed( array $transactionData ): bool {

--- a/tests/Data/CreditCardPaymentBookingData.php
+++ b/tests/Data/CreditCardPaymentBookingData.php
@@ -7,7 +7,7 @@ class CreditCardPaymentBookingData {
 
 	/**
 	 * @param int $amount
-	 * @return array<string,mixed>
+	 * @return array<string,scalar>
 	 */
 	public static function newValidBookingData( int $amount = 100_000 ): array {
 		return [

--- a/tests/Data/PayPalPaymentBookingData.php
+++ b/tests/Data/PayPalPaymentBookingData.php
@@ -10,7 +10,7 @@ class PayPalPaymentBookingData {
 	public const TRANSACTION_ID = 'T4242';
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array<string,string|int>
 	 */
 	public static function newValidBookingData(): array {
 		return [
@@ -43,7 +43,7 @@ class PayPalPaymentBookingData {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array<string,string|int>
 	 */
 	public static function newValidFollowupBookingData(): array {
 		return [

--- a/tests/Unit/DataAccess/ScalarTypeConverterTest.php
+++ b/tests/Unit/DataAccess/ScalarTypeConverterTest.php
@@ -1,0 +1,94 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\Tests\Unit\DataAccess;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\PaymentContext\DataAccess\ScalarTypeConverter;
+
+/**
+ * @covers \WMDE\Fundraising\PaymentContext\DataAccess\ScalarTypeConverter
+ */
+class ScalarTypeConverterTest extends TestCase {
+	/**
+	 * @dataProvider integerConvertibleScalars
+	 */
+	public function testItConvertToIntegers( mixed $value, int $expected ): void {
+		$this->assertSame( $expected, ScalarTypeConverter::toInt( $value ) );
+	}
+
+	/**
+	 * @dataProvider noScalars
+	 */
+	public function testToIntThrowsOnNonScalars( mixed $value ): void {
+		$this->expectException( \InvalidArgumentException::class );
+		ScalarTypeConverter::toInt( $value );
+	}
+
+	/**
+	 * @return iterable<array{scalar,int}>
+	 */
+	public static function integerConvertibleScalars(): iterable {
+		yield [ 0, 0 ];
+		yield [ 1, 1 ];
+		yield [ -1, -1 ];
+		yield [ 1.2, 1 ];
+		yield [ 1.8, 1 ];
+		yield [ '', 0 ];
+		yield [ '5', 5 ];
+		yield [ '-15', -15 ];
+		yield [ '5 ', 5 ];
+		yield [ ' 5', 5 ];
+		yield [ '055', 55 ];
+		yield [ '0xd5', 0 ];
+		yield [ 'NaN', 0 ];
+		yield [ '1abc', 1 ];
+		yield [ '2dogs', 2 ];
+		yield [ '', 0 ];
+		yield [ false, 0 ];
+		yield [ true, 1 ];
+	}
+
+	/**
+	 * @dataProvider stringConvertibleScalars
+	 */
+	public function testItConvertToString( mixed $value, string $expected ): void {
+		$this->assertSame( $expected, ScalarTypeConverter::toString( $value ) );
+	}
+
+	/**
+	 * @dataProvider noScalars
+	 */
+	public function testToStringThrowsOnNonScalars( mixed $value ): void {
+		$this->expectException( \InvalidArgumentException::class );
+		ScalarTypeConverter::toString( $value );
+	}
+
+	/**
+	 * @return iterable<array{scalar,string}>
+	 */
+	public static function stringConvertibleScalars(): iterable {
+		yield [ 0, '0' ];
+		yield [ 1, '1' ];
+		yield [ -1, '-1' ];
+		yield [ 1.2, '1.2' ];
+		yield [ 1.8, '1.8' ];
+		yield [ 'aaaa', 'aaaa' ];
+		yield [ '0xd5', '0xd5' ];
+		yield [ '5', '5' ];
+		yield [ '-15', '-15' ];
+		yield [ false, '' ];
+		yield [ true, '1' ];
+	}
+
+	/**
+	 * @return iterable<array{mixed}>
+	 */
+	public static function noScalars(): iterable {
+		yield [ null ];
+		yield [ [] ];
+		yield [ new \StdClass() ];
+		// We don't test yielding a resource since unit tests should not interact with the system
+	}
+
+}

--- a/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
+++ b/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
@@ -33,7 +33,7 @@ class PayPalBookingTransformerTest extends TestCase {
 	/**
 	 * @dataProvider invalidBookingDataProvider
 	 *
-	 * @param array<mixed> $transactionData
+	 * @param array<scalar> $transactionData
 	 * @return void
 	 */
 	public function testGivenMissingFields_constructorThrowsException( array $transactionData ): void {
@@ -43,7 +43,7 @@ class PayPalBookingTransformerTest extends TestCase {
 	}
 
 	/**
-	 * @return iterable<mixed>
+	 * @return iterable<string,array{array<string,scalar>}>
 	 */
 	public static function invalidBookingDataProvider(): iterable {
 		yield 'empty valuation date' => [ [ 'payer_id' => 72, 'txn_id' => PayPalPaymentBookingData::TRANSACTION_ID ] ];
@@ -52,14 +52,14 @@ class PayPalBookingTransformerTest extends TestCase {
 	}
 
 	/** @dataProvider invalidValuationDateProvider */
-	public function testGivenInvalidValuationDate_ItThrowsException( mixed $invalidValuationDate ): void {
+	public function testGivenInvalidValuationDate_ItThrowsException( string|int $invalidValuationDate ): void {
 		$this->expectException( \InvalidArgumentException::class );
 
 		new PayPalBookingTransformer( [ 'payer_id' => 1, 'payment_date' => $invalidValuationDate ] );
 	}
 
 	/**
-	 * @return iterable<mixed>
+	 * @return iterable<array{scalar}>
 	 */
 	public static function invalidValuationDateProvider(): iterable {
 		yield [ 0 ];

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -166,7 +166,7 @@ class SofortPaymentTest extends TestCase {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array<string,string>
 	 */
 	private function makeValidTransactionData(): array {
 		return [ 'transactionId' => 'yellow', 'valuationDate' => '2001-12-24T17:30:00Z' ];


### PR DESCRIPTION
This fixes a deprecation warning when using PHP 8.2 and fixes PHPStan warnings when using `intval` and `strval` on database results.

While the PHP 8.2 fix is backwards-compatible, the change from `mixed` to scalar types for the booking data is not. Create a new major release after merging.