### PR TITLE
Emergency fix: Ignore PayPal payment receiver

### DIFF
--- a/src/Services/ExternalVerificationService/PayPal/PayPalVerificationService.php
+++ b/src/Services/ExternalVerificationService/PayPal/PayPalVerificationService.php
@@ -38,6 +38,8 @@ class PayPalVerificationService implements VerificationService {
 
 	/**
 	 * @var string Email address of our PayPal account
+	 * @todo Convert to array and remove phpstan-ignore when we allow multiple receivers
+	 * @phpstan-ignore-next-line
 	 */
 	private string $accountEmailAddress;
 
@@ -97,8 +99,10 @@ class PayPalVerificationService implements VerificationService {
 	 * @return bool
 	 */
 	private function matchesReceiverAddress( array $request ): bool {
-		return array_key_exists( 'receiver_email', $request ) &&
-			$request['receiver_email'] === $this->accountEmailAddress;
+		return true;
+		// TODO allow for multiple receivers for legacy recurring payments
+		// return array_key_exists( 'receiver_email', $request ) &&
+		//	$request['receiver_email'] === $this->accountEmailAddress;
 	}
 
 	/**

--- a/tests/System/Services/ExternalVerificationService/PayPal/PayPalVerificationServiceTest.php
+++ b/tests/System/Services/ExternalVerificationService/PayPal/PayPalVerificationServiceTest.php
@@ -18,7 +18,8 @@ use WMDE\Fundraising\PaymentContext\Services\ExternalVerificationService\PayPal\
 class PayPalVerificationServiceTest extends TestCase {
 
 	private const VALID_ACCOUNT_EMAIL = 'foerderpp@wikimedia.de';
-	private const INVALID_ACCOUNT_EMAIL = 'this.is.not@my.email.address';
+	// TODO uncomment when we activate the feature again
+	// private const INVALID_ACCOUNT_EMAIL = 'this.is.not@my.email.address';
 	private const DUMMY_API_URL = 'https://dummy-url.com';
 	private const VALID_PAYMENT_STATUS = 'Completed';
 	private const INVALID_PAYMENT_STATUS = 'Unknown';
@@ -42,17 +43,11 @@ class PayPalVerificationServiceTest extends TestCase {
 	}
 
 	public function testReceiverAddressMismatches_returnsFailureResponse(): void {
-		$response = $this->makeVerificationService( new Client() )->validate( [
-			'receiver_email' => self::INVALID_ACCOUNT_EMAIL
-		] );
-
-		$this->assertEquals( PayPalVerificationService::ERROR_WRONG_RECEIVER, $response->getMessage() );
+		$this->markTestSkipped( 'Disabled test because we disabled the feature. We need allow multiple receivers' );
 	}
 
 	public function testReceiverAddressNotGiven_returnsFailureResponse(): void {
-		$response = $this->makeVerificationService( new Client() )->validate( [] );
-
-		$this->assertEquals( PayPalVerificationService::ERROR_WRONG_RECEIVER, $response->getMessage() );
+		$this->markTestSkipped( 'Disabled test because we disabled the feature.' );
 	}
 
 	public function testPaymentStatusNotConfirmable_returnsFailureResponse(): void {


### PR DESCRIPTION
Don't check receiver for now, we'll change it later to allow for
multiple receivers. We have recurring payments that have an old email
address

This is for https://phabricator.wikimedia.org/T332141
