### PR TITLE
Improve validation of PPL API config

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20,12 +20,6 @@ parameters:
         - message: "#^Method WMDE\\\\Fundraising\\\\PaymentContext\\\\Services\\\\PayPal\\\\PayPalURLGeneratorConfigReader\\:\\:readConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
           count: 1
           path: src/Services/PayPal/PayPalURLGeneratorConfigReader.php
-        - message: "#^Method WMDE\\\\Fundraising\\\\PaymentContext\\\\Services\\\\PayPal\\\\PayPalURLGeneratorConfigReader\\:\\:readConfig\\(\\) should return array but returns mixed\\.$#"
-          count: 1
-          path: src/Services/PayPal/PayPalURLGeneratorConfigReader.php
-        - message: "#^Parameter \\#1 \\$config of static method WMDE\\\\Fundraising\\\\PaymentContext\\\\Services\\\\PayPal\\\\PayPalURLGeneratorConfigReader\\:\\:checkProductAndSubscriptionPlanIdsAreUnique\\(\\) expects array, mixed given\\.$#"
-          count: 1
-          path: src/Services/PayPal/PayPalURLGeneratorConfigReader.php
         - message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:arrayPrototype\\(\\)\\.$#"
           count: 1
           path: src/Services/PayPal/PayPalURLGeneratorConfigSchema.php

--- a/src/Services/PayPal/PayPalURLGeneratorConfigReader.php
+++ b/src/Services/PayPal/PayPalURLGeneratorConfigReader.php
@@ -11,6 +11,10 @@ class PayPalURLGeneratorConfigReader {
 	public static function readConfig( string $fileName ): array {
 		$config = Yaml::parseFile( $fileName );
 
+		if ( !is_array( $config ) ) {
+			throw new \DomainException( 'Configuration file must contain a nested array structure!' );
+		}
+
 		$processor = new Processor();
 		$schema = new PayPalURLGeneratorConfigSchema();
 		$processor->processConfiguration(

--- a/src/Services/PayPal/PayPalURLGeneratorConfigSchema.php
+++ b/src/Services/PayPal/PayPalURLGeneratorConfigSchema.php
@@ -5,24 +5,35 @@ namespace WMDE\Fundraising\PaymentContext\Services\PayPal;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 
 class PayPalURLGeneratorConfigSchema implements ConfigurationInterface {
 	public function getConfigTreeBuilder(): TreeBuilder {
 		$treeBuilder = new TreeBuilder( 'paypal_api' );
 		$treeBuilder->getRootNode()
 			->arrayPrototype()
+				->requiresAtLeastOneElement()
 				->arrayPrototype()
 					->children()
-						->scalarNode( 'product_id' )->end()
-						->scalarNode( 'product_name' )->end()
-						->scalarNode( 'return_url' )->end()
-						->scalarNode( 'cancel_url' )->end()
+						->scalarNode( 'product_id' )->isRequired()->end()
+						->scalarNode( 'product_name' )->isRequired()->end()
+						->scalarNode( 'return_url' )->isRequired()->end()
+						->scalarNode( 'cancel_url' )->isRequired()->end()
 						->arrayNode( 'subscription_plans' )
+							->isRequired()
 							->arrayPrototype()
 								->children()
-									->scalarNode( 'id' )->end()
-									->scalarNode( 'name' )->end()
-									->scalarNode( 'interval' )->end()
+									->scalarNode( 'id' )->isRequired()->end()
+									->scalarNode( 'name' )->isRequired()->end()
+									->enumNode( 'interval' )
+										->isRequired()
+										->values( [
+											PaymentInterval::Monthly->name,
+											PaymentInterval::Quarterly->name,
+											PaymentInterval::HalfYearly->name,
+											PaymentInterval::Yearly->name
+										] )
+									->end()
 								->end()
 							->end()
 						->end()

--- a/tests/Data/PayPalAPIURLGeneratorConfig/paypal_api_empty.yml
+++ b/tests/Data/PayPalAPIURLGeneratorConfig/paypal_api_empty.yml
@@ -1,0 +1,1 @@
+#This YAML file is intentionally empty to test the YAML return type when reading it

--- a/tests/Data/PayPalAPIURLGeneratorConfig/paypal_api_no_language.yml
+++ b/tests/Data/PayPalAPIURLGeneratorConfig/paypal_api_no_language.yml
@@ -1,0 +1,2 @@
+# Broken test configuration to test checks for missing language items and configuration
+donation:

--- a/tests/Data/PayPalAPIURLGeneratorConfig/paypal_api_no_plans.yml
+++ b/tests/Data/PayPalAPIURLGeneratorConfig/paypal_api_no_plans.yml
@@ -1,0 +1,3 @@
+# Broken test configuration to test checks for missing configuration for a language item
+donation:
+  de_DE:

--- a/tests/Unit/Services/PayPal/PayPalURLGeneratorConfigReaderTest.php
+++ b/tests/Unit/Services/PayPal/PayPalURLGeneratorConfigReaderTest.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Services\PayPal;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Yaml\Exception\ParseException;
 use WMDE\Fundraising\PaymentContext\Services\PayPal\PayPalURLGeneratorConfigReader;
 
 /**
@@ -18,12 +20,36 @@ class PayPalURLGeneratorConfigReaderTest extends TestCase {
 	public function testProductIdsMustBeUnique(): void {
 		$this->expectException( \DomainException::class );
 		$this->expectExceptionMessage( "All product IDs in the configuration file must be unique!" );
-		$config = PayPalURLGeneratorConfigReader::readConfig( __DIR__ . '/../../../Data/PayPalAPIURLGeneratorConfig/paypal_api_duplicate_product_id.yml' );
+		PayPalURLGeneratorConfigReader::readConfig( __DIR__ . '/../../../Data/PayPalAPIURLGeneratorConfig/paypal_api_duplicate_product_id.yml' );
 	}
 
 	public function testSubscriptionPlanIdsMustBeUnique(): void {
 		$this->expectException( \DomainException::class );
 		$this->expectExceptionMessage( "All subscription plan IDs in the configuration file must be unique!" );
-		$config = PayPalURLGeneratorConfigReader::readConfig( __DIR__ . '/../../../Data/PayPalAPIURLGeneratorConfig/paypal_api_duplicate_plan_id.yml' );
+		PayPalURLGeneratorConfigReader::readConfig( __DIR__ . '/../../../Data/PayPalAPIURLGeneratorConfig/paypal_api_duplicate_plan_id.yml' );
+	}
+
+	public function testFileMustContainAtLeastOneLanguage(): void {
+		$this->expectException( InvalidConfigurationException::class );
+		$this->expectExceptionMessage( 'The path "paypal_api.donation" should have at least 1 element(s) defined.' );
+		PayPalURLGeneratorConfigReader::readConfig( __DIR__ . '/../../../Data/PayPalAPIURLGeneratorConfig/paypal_api_no_language.yml' );
+	}
+
+	public function testFileMustContainAtLeastOnePlan(): void {
+		$this->expectException( InvalidConfigurationException::class );
+		$this->expectExceptionMessage( 'The child config "product_id" under "paypal_api.donation.de_DE" must be configured.' );
+		PayPalURLGeneratorConfigReader::readConfig( __DIR__ . '/../../../Data/PayPalAPIURLGeneratorConfig/paypal_api_no_plans.yml' );
+	}
+
+	public function testReadingFromEmptyFileThrowsException(): void {
+		$this->expectException( \DomainException::class );
+		$this->expectExceptionMessage( 'Configuration file must contain a nested array structure!' );
+		PayPalURLGeneratorConfigReader::readConfig( __DIR__ . '/../../../Data/PayPalAPIURLGeneratorConfig/paypal_api_empty.yml' );
+	}
+
+	public function testReadingFromNonexistentFileThrowsException(): void {
+		$this->expectException( ParseException::class );
+		$this->expectExceptionMessageMatches( '#does/not/exist/plan.yml" does not exist#' );
+		PayPalURLGeneratorConfigReader::readConfig( __DIR__ . '/this/path/does/not/exist/plan.yml' );
 	}
 }


### PR DESCRIPTION
Use Symfony TreeBuilder checks to check the structure of the PayPal API configuration.

Add tests for missing and empty file.

This is for https://phabricator.wikimedia.org/T329161