### PR TITLE
Relax exception check for unique constraints

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,14 +2,6 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 parameters:
-	ignoreErrors:
-		# A workaround for Doctrine not specifying an UniqueConstraintViolationException being thrown
-		# See https://github.com/doctrine/orm/issues/7780
-		# This rule might be unneccessary in the future with a fixe discussed in
-		# https://github.com/phpstan/phpstan-doctrine/issues/295
-		- message: /Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException is never thrown in the try block/
-		  path: src/DataAccess/DoctrinePaymentRepository.php
-		  count: 1
 
 	excludePaths:
 		analyse:

--- a/src/DataAccess/DoctrinePaymentRepository.php
+++ b/src/DataAccess/DoctrinePaymentRepository.php
@@ -17,7 +17,9 @@ class DoctrinePaymentRepository implements PaymentRepository {
 		$this->entityManager->persist( $payment );
 		try {
 			$this->entityManager->flush();
-		} catch ( UniqueConstraintViolationException $ex ) {
+			// TODO Remove allowing \RuntimeException when the discussion on https://github.com/doctrine/orm/pull/10785
+			//      has been resolved. Hopefully, they'll re-introduce UniqueConstraintViolationException in a patch release
+		} catch ( UniqueConstraintViolationException|\RuntimeException $ex ) {
 			throw new PaymentOverrideException( $ex->getMessage(), $ex->getCode(), $ex );
 		}
 	}


### PR DESCRIPTION
This is a temporary workaround for the changes made in
Doctrine ORM 2.16, discussed in
https://github.com/doctrine/orm/pull/10785

When that discussion is resolved, we should remove the check for
`RuntimeException`, because it might be thrown by other errors that have
nothing to do with duplicate IDs, which would lead to our
`PaymentOverrideException` hinting at the wrong thing.

Also remove the PHPStan rule that had an exception for this check.
When the Exception comes back, the method should have an annotation that
it's thrown. Otherwise we'll have to put the PHPStan rule back or try
out phpstan-doctrine where this has been solved:
https://github.com/phpstan/phpstan-doctrine/pull/315
