### PR TITLE
Additional error handling for duplicate IDs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"wmde/fun-validators": "~v4.0.0",
 		"wmde/freezable-value-object": "~2.0",
 
-		"doctrine/orm": "^2.11",
+		"doctrine/orm": "^2.16.1",
 		"doctrine/dbal": "^3.3",
 		"doctrine/migrations": "^3.5",
 		"sofort/sofortlib-php": "^3.2",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
 	ignoreErrors:
 		# A workaround for Doctrine not specifying an UniqueConstraintViolationException being thrown
 		# See https://github.com/doctrine/orm/issues/7780
-		# This rule might be unneccessary in the future with a fixe discussed in
+		# This rule might be unneccessary in the future with a fix discussed in
 		# https://github.com/phpstan/phpstan-doctrine/issues/295
 		- message: /Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException is never thrown in the try block/
 		  path: src/DataAccess/DoctrinePaymentRepository.php


### PR DESCRIPTION
Doctrine ORM 2.16 introduced a check for different Entities with the same ID in the `persist` method. Previously, we checked for an exception thrown by the database layer (`flush` method), now we also need to check on persist.

