### PR TITLE
Prepare Database for One-Time payments

### DIFF
--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.PayPalOrder.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.PayPalOrder.dcm.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\PayPalOrder">
-        <field name="transactionId" type="string" column="transaction_id" nullable="false" />
+        <field name="transactionId" type="string" column="transaction_id" nullable="true" />
+        <field name="orderId" type="string" column="order_id" nullable="false" />
+
+        <indexes>
+            <index name="transaction_id_idx" columns="transaction_id" />
+            <index name="order_id_idx" columns="order_id" />
+        </indexes>
     </entity>
 </doctrine-mapping>

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.PayPalSubscription.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.PayPalSubscription.dcm.xml
@@ -2,5 +2,9 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\PayPalSubscription">
         <field name="subscriptionId" type="string" column="subscription_id" nullable="false" />
+
+        <indexes>
+            <index name="subscription_id_idx" columns="subscription_id" />
+        </indexes>
     </entity>
 </doctrine-mapping>

--- a/src/DataAccess/Migrations/Version20231012164127.php
+++ b/src/DataAccess/Migrations/Version20231012164127.php
@@ -1,0 +1,37 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\DataAccess\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231012164127 extends AbstractMigration {
+	public function getDescription(): string {
+		return 'Add payment_paypal_identifier table and indexes';
+	}
+
+	public function up( Schema $schema ): void {
+		$this->addSql( <<<'EOT'
+CREATE TABLE payment_paypal_identifier (
+    payment_id INT NOT NULL,
+    identifier_type VARCHAR(1) NOT NULL,
+    subscription_id VARCHAR(255) DEFAULT NULL,
+    transaction_id VARCHAR(255) DEFAULT NULL,
+    order_id VARCHAR(255) DEFAULT NULL,
+    PRIMARY KEY(payment_id)
+) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB
+EOT
+		);
+		$this->addSql( 'ALTER TABLE payment_paypal_identifier ADD CONSTRAINT FK_D7AFB034C3A3BB FOREIGN KEY (payment_id) REFERENCES payment (id)' );
+		$this->addSql( 'CREATE INDEX payment_paypal_identifier_transaction_id_index ON payment_paypal_identifier (transaction_id)' );
+		$this->addSql( 'CREATE INDEX payment_paypal_identifier_order_id_index ON payment_paypal_identifier (order_id)' );
+		$this->addSql( 'CREATE INDEX payment_paypal_identifier_subscription_id_index ON payment_paypal_identifier (subscription_id)' );
+	}
+
+	public function down( Schema $schema ): void {
+		$this->addSql( 'ALTER TABLE payment_paypal_identifier DROP FOREIGN KEY FK_D7AFB034C3A3BB' );
+		$this->addSql( 'DROP TABLE payment_paypal_identifier' );
+	}
+}

--- a/src/Domain/Model/PayPalOrder.php
+++ b/src/Domain/Model/PayPalOrder.php
@@ -3,24 +3,44 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\PaymentContext\Domain\Model;
 
+/**
+ * Creating an order via API only returns the order ID.
+ * The transaction ID must be set later when the user returns from the payment provider
+ */
 class PayPalOrder extends PayPalPaymentIdentifier {
-	private string $transactionId;
+	private ?string $transactionId;
+	private string $orderId;
 
-	public function __construct( PayPalPayment $payment, string $transactionId ) {
+	public function __construct( PayPalPayment $payment, string $orderID, ?string $transactionId = null ) {
 		if ( $payment->getInterval()->isRecurring() ) {
 			throw new \DomainException( self::class . ' can only be used for one-time payments' );
 		}
-		$trimmedTransactionId = trim( $transactionId );
-		if ( empty( $trimmedTransactionId ) ) {
-			throw new \DomainException( 'Transaction ID must not be empty' );
+		$trimmedOrderId = trim( $orderID );
+		if ( empty( $trimmedOrderId ) ) {
+			throw new \DomainException( 'Order ID must not be empty' );
 		}
 
 		parent::__construct( $payment );
+		$this->orderId = $trimmedOrderId;
 		$this->transactionId = $transactionId;
 	}
 
-	public function getTransactionId(): string {
+	public function getTransactionId(): ?string {
 		return $this->transactionId;
+	}
+
+	public function setTransactionId( string $transactionId ): void {
+		if ( trim( $transactionId ) === '' ) {
+			throw new \DomainException( 'Transaction ID must not be empty when setting it explicitly' );
+		}
+		if ( $this->transactionId !== null && $this->transactionId !== $transactionId ) {
+			throw new \DomainException( 'Transaction ID must not be changed' );
+		}
+		$this->transactionId = $transactionId;
+	}
+
+	public function getOrderId(): string {
+		return $this->orderId;
 	}
 
 }

--- a/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
@@ -429,10 +429,11 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	public function testStorePayPalIdentifierForOneTimePayment(): void {
 		$repo = new DoctrinePaymentRepository( $this->entityManager );
 		$payment = new PayPalPayment( 9, Euro::newFromInt( 87 ), PaymentInterval::OneTime );
-		$repo->storePayPalIdentifier( new PayPalOrder( $payment, 'TXN-9' ) );
+		$repo->storePayPalIdentifier( new PayPalOrder( $payment, 'O-1234', 'TXN-9' ) );
 
 		$identifier = $this->fetchRawPayPalIdentifier( 9 );
 		$this->assertSame( 9, $identifier['payment_id'] );
+		$this->assertSame( 'O-1234', $identifier['order_id'] );
 		$this->assertSame( 'TXN-9', $identifier['transaction_id'] );
 		$this->assertSame( 'O', $identifier['identifier_type'] );
 	}
@@ -641,7 +642,7 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 	 */
 	private function fetchRawPayPalIdentifier( int $paymentId ): array {
 		$data = $this->connection->createQueryBuilder()
-			->select( 'p.subscription_id', 'p.transaction_id', 'p.payment_id', 'p.identifier_type' )
+			->select( 'p.subscription_id', 'p.order_id', 'p.transaction_id', 'p.payment_id', 'p.identifier_type' )
 			->from( 'payment_paypal_identifier', 'p' )
 			->where( 'p.payment_id = :payment_id' )
 			->setParameter( 'payment_id', $paymentId, ParameterType::INTEGER )

--- a/tests/Unit/Domain/Model/PayPalOrderTest.php
+++ b/tests/Unit/Domain/Model/PayPalOrderTest.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types=1 );
 
-namespace Unit\Domain\Model;
+namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
 use WMDE\Euro\Euro;
@@ -14,27 +14,30 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
  * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPaymentIdentifier
  */
 class PayPalOrderTest extends TestCase {
+
+	private const ORDER_ID = '5O190127TN364715T';
 	private const TRANSACTION_ID = '2GG279541U471931P';
+	private const ANOTHER_TRANSACTION_ID = '3HH380652V580042Q';
 
 	public function testConstructorAllowsOnlyForOneTimePayment(): void {
 		$this->expectException( \DomainException::class );
 
-		new PayPalOrder( new PayPalPayment( 1, Euro::newFromCents( 1000 ), PaymentInterval::Monthly ), self::TRANSACTION_ID );
+		new PayPalOrder( new PayPalPayment( 1, Euro::newFromCents( 1000 ), PaymentInterval::Monthly ), self::ORDER_ID );
 	}
 
 	/**
-	 * @dataProvider provideEmptyTransactionIDs
+	 * @dataProvider provideEmptyIDs
 	 */
-	public function testConstructorEnforcesNonEmptyTransactionId( string $transactionId ): void {
+	public function testConstructorEnforcesNonEmptyOrderId( string $orderId ): void {
 		$this->expectException( \DomainException::class );
 
-		new PayPalOrder( $this->givenOneTimePayment(), $transactionId );
+		new PayPalOrder( $this->givenOneTimePayment(), $orderId );
 	}
 
 	/**
 	 * @return iterable<array{string}>
 	 */
-	public static function provideEmptyTransactionIDs(): iterable {
+	public static function provideEmptyIDs(): iterable {
 		yield 'empty string' => [ '' ];
 		yield 'string consisting of spaces' => [ '   ' ];
 		yield 'string consisting of whitespace characters' => [ "\t\r\n " ];
@@ -42,10 +45,31 @@ class PayPalOrderTest extends TestCase {
 
 	public function testConstructorSetsProperties(): void {
 		$payment = $this->givenOneTimePayment();
-		$order = new PayPalOrder( $payment, self::TRANSACTION_ID );
+		$order = new PayPalOrder( $payment, self::ORDER_ID, self::TRANSACTION_ID );
 
 		$this->assertSame( $payment, $order->getPayment() );
+		$this->assertSame( self::ORDER_ID, $order->getOrderId() );
 		$this->assertSame( self::TRANSACTION_ID, $order->getTransactionId() );
+	}
+
+	/**
+	 * @dataProvider provideEmptyIDs
+	 */
+	public function testSettingEmptyTransactionIdThrowException( string $transactionId ): void {
+		$order = new PayPalOrder( $this->givenOneTimePayment(), self::ORDER_ID );
+
+		$this->expectException( \DomainException::class );
+		$this->expectExceptionMessage( 'Transaction ID must not be empty when setting it explicitly' );
+		$order->setTransactionId( $transactionId );
+	}
+
+	public function testWhenTransactionIdHasBeenSetItMustNotChange(): void {
+		$order = new PayPalOrder( $this->givenOneTimePayment(), self::ORDER_ID );
+		$order->setTransactionId( self::TRANSACTION_ID );
+
+		$this->expectException( \DomainException::class );
+		$this->expectExceptionMessage( 'Transaction ID must not be changed' );
+		$order->setTransactionId( self::ANOTHER_TRANSACTION_ID );
 	}
 
 	private function givenOneTimePayment(): PayPalPayment {


### PR DESCRIPTION
This prepares the database layer for the two-step process of creating a
one-time-payment (Order) with the PayPal API:
- The first API call creates the Order, returning an Order ID
- When the user comes back from the payment provider to the return URL,
  the URL will contain the Order ID parameter and we'll have to make
  another API request to *capture* the order, which will return a
  transaction ID. We won't *book* the payment (that's still done in the
  IPN handling), but we will store the returned transaction ID in the
  PayPalOrder class, so the notification code can lookup the payment via
  transaction ID.

This change also introduces indexes for the `PayPalPaymentIdentifier`
subclasses `PayPalOrder` and `PayPalSubscription` and creates a database migration.

Ticket: https://phabricator.wikimedia.org/T344839