### PR TITLE
Store valuation date in UTC

### DIFF
--- a/src/Domain/Model/BookingDataTransformers/CreditCardBookingTransformer.php
+++ b/src/Domain/Model/BookingDataTransformers/CreditCardBookingTransformer.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\PaymentContext\Domain\Model\BookingDataTransformers;
 
 use WMDE\Euro\Euro;
+use WMDE\Fundraising\PaymentContext\Domain\Model\ValuationDateTimeZone;
 
 class CreditCardBookingTransformer {
 
@@ -32,12 +33,16 @@ class CreditCardBookingTransformer {
 
 	/**
 	 * @param array<string, scalar> $rawBookingData
-	 * @param \DateTimeImmutable|null $valuationDate
+	 * @param \DateTimeImmutable|null $valuationDate This parameter exists only for testing (and passing in a fixed time). The CreditCardPayment will always omit the parameter.
 	 */
 	public function __construct( array $rawBookingData, ?\DateTimeImmutable $valuationDate = null ) {
 		$this->validateRawData( $rawBookingData );
 		$this->rawBookingData = $rawBookingData;
-		$this->valuationDate = $valuationDate ?? new \DateTimeImmutable();
+		if ( $valuationDate === null ) {
+			$this->valuationDate = new \DateTimeImmutable( 'now', ValuationDateTimeZone::getTimeZone() );
+		} else {
+			$this->valuationDate = $valuationDate->setTimezone( ValuationDateTimeZone::getTimeZone() );
+		}
 	}
 
 	/**

--- a/src/Domain/Model/BookingDataTransformers/PayPalBookingTransformer.php
+++ b/src/Domain/Model/BookingDataTransformers/PayPalBookingTransformer.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\PaymentContext\Domain\Model\BookingDataTransformers;
 
+use WMDE\Fundraising\PaymentContext\Domain\Model\ValuationDateTimeZone;
+
 class PayPalBookingTransformer {
 
 	private const PAYER_ID_KEY = 'payer_id';
@@ -92,6 +94,7 @@ class PayPalBookingTransformer {
 			) );
 		}
 
+		$valuationDate = $valuationDate->setTimezone( ValuationDateTimeZone::getTimeZone() );
 		$this->valuationDate = $valuationDate;
 		$this->transactionId = strval( $rawBookingData[self::TRANSACTION_ID_KEY] );
 		$this->rawBookingData = $this->anonymise( $rawBookingData );

--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -87,6 +87,7 @@ class SofortPayment extends Payment implements BookablePayment {
 			}
 			throw new DomainException( $msg );
 		}
+		$valuationDate = $valuationDate->setTimezone( ValuationDateTimeZone::getTimeZone() );
 		$this->valuationDate = $valuationDate;
 		return $this;
 	}

--- a/src/Domain/Model/ValuationDateTimeZone.php
+++ b/src/Domain/Model/ValuationDateTimeZone.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace WMDE\Fundraising\PaymentContext\Domain\Model;
+
+class ValuationDateTimeZone {
+
+	private const TIMEZONE = 'UTC';
+
+	public static function getTimeZone(): \DateTimeZone {
+		return new \DateTimeZone( self::TIMEZONE );
+	}
+}

--- a/tests/Data/PayPalPaymentBookingData.php
+++ b/tests/Data/PayPalPaymentBookingData.php
@@ -7,6 +7,7 @@ namespace WMDE\Fundraising\PaymentContext\Tests\Data;
 class PayPalPaymentBookingData {
 
 	public const PAYMENT_DATE = '10:54:49 Dec 02, 2012 PST';
+	public const PAYMENT_DATE_UTC = '2012-12-02 18:54:49';
 	public const TRANSACTION_ID = 'T4242';
 
 	/**

--- a/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
@@ -121,7 +121,7 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 		$this->assertSame( 9900, $insertedPayment['amount'] );
 		$this->assertSame( 3, $insertedPayment['payment_interval'] );
 		$this->assertSame( 'PPL', $insertedPayment['payment_method'] );
-		$this->assertSame( '2012-12-02 10:54:49', $insertedPayment['valuation_date'] );
+		$this->assertSame( '2012-12-02 18:54:49', $insertedPayment['valuation_date'] );
 		$this->assertNull( $insertedPayment['parent_payment_id'] );
 		$this->assertSame( PayPalPaymentBookingData::newEncodedValidBookingData(), $insertedPayment['booking_data'] );
 	}

--- a/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
+++ b/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Domain\Model\BookingDataTra
 
 use PHPUnit\Framework\TestCase;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BookingDataTransformers\PayPalBookingTransformer;
+use WMDE\Fundraising\PaymentContext\Domain\Model\ValuationDateTimeZone;
 use WMDE\Fundraising\PaymentContext\Tests\Data\PayPalPaymentBookingData;
 
 /**
@@ -72,6 +73,16 @@ class PayPalBookingTransformerTest extends TestCase {
 		$transformer = new PayPalBookingTransformer( PayPalPaymentBookingData::newValidBookingData() );
 
 		$this->assertEquals( new \DateTimeImmutable( PayPalPaymentBookingData::PAYMENT_DATE ), $transformer->getValuationDate() );
+	}
+
+	public function testTransformerConvertsValuationDateToUTC(): void {
+		$transformer = new PayPalBookingTransformer( PayPalPaymentBookingData::newValidBookingData() );
+		$expectedValuationDate = new \DateTimeImmutable( PayPalPaymentBookingData::PAYMENT_DATE_UTC, ValuationDateTimeZone::getTimeZone() );
+
+		$valuationDate = $transformer->getValuationDate();
+
+		$this->assertEquals( ValuationDateTimeZone::getTimeZone(), $valuationDate->getTimezone() );
+		$this->assertEquals( $expectedValuationDate, $valuationDate );
 	}
 
 	public function testGetTransactionId(): void {

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -10,6 +10,7 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\LegacyPaymentStatus;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentReferenceCode;
 use WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\ValuationDateTimeZone;
 use WMDE\Fundraising\PaymentContext\Tests\Fixtures\DummyPaymentIdRepository;
 use WMDE\Fundraising\PaymentContext\Tests\Inspectors\SofortPaymentInspector;
 
@@ -76,7 +77,10 @@ class SofortPaymentTest extends TestCase {
 
 		$sofortPayment->bookPayment( $this->makeValidTransactionData(), new DummyPaymentIdRepository() );
 
-		$this->assertEquals( new \DateTimeImmutable( '2001-12-24T17:30:00Z' ), $sofortPayment->getValuationDate() );
+		$this->assertEquals(
+			new \DateTimeImmutable( '2001-12-24T17:30:00', ValuationDateTimeZone::getTimeZone() ),
+			$sofortPayment->getValuationDate()
+		);
 	}
 
 	public function testBookPaymentSetsTransactionId(): void {


### PR DESCRIPTION
All external payments now store their valuation date as (or rather the
time zone that's returned by he ValuationDateTimeZone) factory class.

Previously, the time zone information was just dropped, leading to
inaccurate valuation dates. This lead to troubles in the accounting
department where the PayPal payments (sent in PDT time zone) were off by
a day for a period of 6-8 hours.

The database column doesn't store the timezone information (and doesn't
need to, now that we've standardized on UTC).

https://phabricator.wikimedia.org/T349928
