### PR TITLE
Fix SofortURLGenerator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.0.x-dev"
+			"dev-main": "7.0.x-dev"
 		}
 	}
 }

--- a/src/Services/PaymentUrlGenerator/SofortURLGenerator.php
+++ b/src/Services/PaymentUrlGenerator/SofortURLGenerator.php
@@ -40,7 +40,12 @@ class SofortURLGenerator implements PaymentCompletionURLGenerator {
 		);
 		$request->setAbortUrl( $this->config->getCancelUrl() );
 		$request->setNotificationUrl(
-			$this->authenticator->addAuthenticationTokensToApplicationUrl( $this->config->getNotificationUrl() )
+			$this->config->getNotificationUrl() . '?' . http_build_query(
+				$this->authenticator->getAuthenticationTokensForPaymentProviderUrl(
+					self::class,
+					[ 'id', 'updateToken' ]
+				)
+			)
 		);
 		$request->setLocale( $this->config->getLocale() );
 

--- a/tests/Fixtures/FakeUrlAuthenticator.php
+++ b/tests/Fixtures/FakeUrlAuthenticator.php
@@ -7,6 +7,7 @@ use WMDE\Fundraising\PaymentContext\Services\URLAuthenticator;
 
 class FakeUrlAuthenticator implements URLAuthenticator {
 	public const TOKEN_PARAM = 'testAccessToken=LET_ME_IN';
+	public const PAYMENT_PROVIDER_PARAM_PREFIX = 'p-test-param-';
 
 	public function addAuthenticationTokensToApplicationUrl( string $url ): string {
 		$urlParts = parse_url( $url );
@@ -39,7 +40,7 @@ class FakeUrlAuthenticator implements URLAuthenticator {
 	public function getAuthenticationTokensForPaymentProviderUrl( string $urlGeneratorClass, array $requestedParameters ): array {
 		$resultParameters = [];
 		foreach ( $requestedParameters as $idx => $parameter ) {
-			$resultParameters[$parameter] = 'p-test-token-' . $idx;
+			$resultParameters[$parameter] = self::PAYMENT_PROVIDER_PARAM_PREFIX . $idx;
 		}
 		return $resultParameters;
 	}

--- a/tests/Unit/Services/PaymentUrlGenerator/CreditCardURLGeneratorTest.php
+++ b/tests/Unit/Services/PaymentUrlGenerator/CreditCardURLGeneratorTest.php
@@ -91,7 +91,7 @@ class CreditCardURLGeneratorTest extends TestCase {
 		$this->assertSame(
 			'https://credit-card.micropayment.de/creditcard/event/index.php?project=wikimedia&bgcolor=CCE7CD&' .
 			'paytext=Ich+spende+einmalig&mp_user_firstname=Kai&mp_user_surname=Nissen&sid=1234567&gfx=wikimedia_black&' .
-			'amount=100&theme=wikimedia&producttype=fee&lang=de&token=p-test-token-0&utoken=p-test-token-1&testmode=1',
+			'amount=100&theme=wikimedia&producttype=fee&lang=de&token=p-test-param-0&utoken=p-test-param-1&testmode=1',
 			$urlGenerator->generateUrl( $requestContext )
 		);
 	}
@@ -104,7 +104,7 @@ class CreditCardURLGeneratorTest extends TestCase {
 			[
 				'https://credit-card.micropayment.de/creditcard/event/index.php?project=wikimedia&bgcolor=CCE7CD&' .
 				'paytext=Ich+spende+einmalig&mp_user_firstname=Kai&mp_user_surname=Nissen&sid=1234567&gfx=wikimedia_black&' .
-				'amount=500&theme=wikimedia&producttype=fee&lang=de&token=p-test-token-0&utoken=p-test-token-1',
+				'amount=500&theme=wikimedia&producttype=fee&lang=de&token=p-test-param-0&utoken=p-test-param-1',
 				'Kai',
 				'Nissen',
 				'Ich spende einmalig',
@@ -118,7 +118,7 @@ class CreditCardURLGeneratorTest extends TestCase {
 			[
 				'https://credit-card.micropayment.de/creditcard/event/index.php?project=wikimedia&bgcolor=CCE7CD&' .
 				'paytext=Ich+spende+monatlich&mp_user_firstname=Kai&mp_user_surname=Nissen&sid=1234567&gfx=wikimedia_black&' .
-				'amount=123&theme=wikimedia&producttype=fee&lang=de&token=p-test-token-0&utoken=p-test-token-1',
+				'amount=123&theme=wikimedia&producttype=fee&lang=de&token=p-test-param-0&utoken=p-test-param-1',
 				'Kai',
 				'Nissen',
 				'Ich spende monatlich',
@@ -132,7 +132,7 @@ class CreditCardURLGeneratorTest extends TestCase {
 			[
 				'https://credit-card.micropayment.de/creditcard/event/index.php?project=wikimedia&bgcolor=CCE7CD&' .
 				'paytext=Ich+spende+halbj%C3%A4hrlich&mp_user_firstname=Kai&mp_user_surname=Nissen&sid=1234567&' .
-				'gfx=wikimedia_black&amount=1250&theme=wikimedia&producttype=fee&lang=de&token=p-test-token-0&utoken=p-test-token-1',
+				'gfx=wikimedia_black&amount=1250&theme=wikimedia&producttype=fee&lang=de&token=p-test-param-0&utoken=p-test-param-1',
 				'Kai',
 				'Nissen',
 				'Ich spende halbjährlich',

--- a/tests/Unit/Services/PaymentUrlGenerator/LegacyPayPalURLGeneratorTest.php
+++ b/tests/Unit/Services/PaymentUrlGenerator/LegacyPayPalURLGeneratorTest.php
@@ -150,7 +150,7 @@ class LegacyPayPalURLGeneratorTest extends TestCase {
 			'return=https%3A%2F%2Fmy.donation.app%2Fdonation%2Fconfirm%2F%3Fid%3D1234%26testAccessToken%3DLET_ME_IN',
 			$generatedUrl
 		);
-		$this->assertStringContainsString( 'custom=p-test-token-0', $generatedUrl );
+		$this->assertStringContainsString( 'custom=p-test-param-0', $generatedUrl );
 	}
 
 	private function assertSinglePaymentRelatedParamsSet( string $generatedUrl ): void {

--- a/tests/Unit/Services/PaymentUrlGenerator/SofortURLGeneratorTest.php
+++ b/tests/Unit/Services/PaymentUrlGenerator/SofortURLGeneratorTest.php
@@ -54,7 +54,9 @@ class SofortURLGeneratorTest extends TestCase {
 		$urlGenerator->generateUrl( $requestContext );
 
 		$this->assertStringContainsString( "testAccessToken=LET_ME_IN", $client->request->getSuccessUrl() );
-		$this->assertStringContainsString( "testAccessToken=LET_ME_IN", $client->request->getNotificationUrl() );
+		$notificationUrl = $client->request->getNotificationUrl();
+		$this->assertStringContainsString( "id=p-test-param-", $notificationUrl );
+		$this->assertStringContainsString( "updateToken=p-test-param-", $notificationUrl );
 		$this->assertSame( $amount, $client->request->getAmount() );
 		$this->assertSame( $locale, $client->request->getLocale() );
 	}


### PR DESCRIPTION
Commit 744a69815dbc5b017ebeff6e2a38774dff475954 introduced an error
where the `SofortURLGenerator` appended the wrong parameters to the
notification URL (`accessToken` instead of `updateToken`). This commit
fixes SofortURLGenerator.

This commit also changes the generated value in FakeUrlAuthenticator
because it generates *parameters* and not only *tokens*. This results in
changes for all URL Generator classes.

This fixes https://phabricator.wikimedia.org/T350149
