### PR TITLE
Validate interval for Sofort payments

### DIFF
--- a/src/UseCases/CreatePayment/CreatePaymentUseCase.php
+++ b/src/UseCases/CreatePayment/CreatePaymentUseCase.php
@@ -102,15 +102,12 @@ class CreatePaymentUseCase {
 		);
 	}
 
-	/**
-	 * @param PaymentParameters $parameters
-	 * @return SofortPayment
-	 * @throws PaymentCreationException
-	 */
 	private function createSofortPayment( PaymentParameters $parameters ): SofortPayment {
 		$paymentInterval = PaymentInterval::from( $parameters->interval );
+		// This check is a belt-and-suspenders approach to make sure the validator is working and was called
+		// before this method. It should never be triggered.
 		if ( $paymentInterval->isRecurring() ) {
-			throw new PaymentCreationException( "Sofort payment does not support recurring intervals (>0)." );
+			throw new \LogicException( "The validator did not catch the recurring payment, please check your code" );
 		}
 
 		return SofortPayment::create(

--- a/tests/Unit/UseCases/CreatePayment/CreatePaymentUseCaseTest.php
+++ b/tests/Unit/UseCases/CreatePayment/CreatePaymentUseCaseTest.php
@@ -182,7 +182,7 @@ class CreatePaymentUseCaseTest extends TestCase {
 		) );
 
 		$this->assertInstanceOf( FailureResponse::class, $result );
-		$this->assertMatchesRegularExpression( '/Sofort.*interval/', $result->errorMessage );
+		$this->assertStringContainsString( 'Sofort payments cannot be recurring', $result->errorMessage );
 	}
 
 	public function testCreatePaymentWithInvalidIntervalFails(): void {


### PR DESCRIPTION
Instead of relying on outside factors or validation, make the rule that
Sofort payments can only be one-time (because the API and the provider
does not *allow* recurring payments) a validation rule.

https://phabricator.wikimedia.org/T350848
