### PR TITLE
Group patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       interval: "daily"
     # Temporarily disabled automated update PRs for this repository
     open-pull-requests-limit: 0
+    groups:
+      patch-updates:
+        update-types:
+          - patch


### PR DESCRIPTION
- this change will prevent dependabot from creating a single pull request for every patch version update of a dependency but group them (like in many other of our repos now)