### PR TITLE
Add coverage tags

### DIFF
--- a/src/Commands/CreateSubscriptionPlansCommand.php
+++ b/src/Commands/CreateSubscriptionPlansCommand.php
@@ -17,6 +17,9 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreateSubscriptionPlansForProduct\C
 use WMDE\Fundraising\PaymentContext\UseCases\CreateSubscriptionPlansForProduct\ErrorResult;
 use WMDE\Fundraising\PaymentContext\UseCases\CreateSubscriptionPlansForProduct\SuccessResult;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[AsCommand(
 	name: 'app:create-subscription-plans',
 	description: 'Create subscription plan for recurring payments with PayPal.',

--- a/src/Commands/ListSubscriptionPlansCommand.php
+++ b/src/Commands/ListSubscriptionPlansCommand.php
@@ -11,6 +11,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use WMDE\Fundraising\PaymentContext\Services\PayPal\PaypalAPI;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[AsCommand(
 	name: 'app:list-subscription-plans',
 	description: 'Lists existing PayPal subscription plans.',

--- a/src/PaymentContextFactory.php
+++ b/src/PaymentContextFactory.php
@@ -7,6 +7,9 @@ namespace WMDE\Fundraising\PaymentContext;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 
+/**
+ * @codeCoverageIgnore
+ */
 class PaymentContextFactory {
 
 	private const DOCTRINE_CLASS_MAPPING_DIRECTORY = __DIR__ . '/../config/DoctrineClassMapping';

--- a/tests/System/Services/ExternalVerificationService/PayPal/PayPalVerificationServiceTest.php
+++ b/tests/System/Services/ExternalVerificationService/PayPal/PayPalVerificationServiceTest.php
@@ -14,6 +14,7 @@ use WMDE\Fundraising\PaymentContext\Services\ExternalVerificationService\PayPal\
 
 /**
  * @covers \WMDE\Fundraising\PaymentContext\Services\ExternalVerificationService\PayPal\PayPalVerificationService
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\BookPayment\VerificationResponse
  */
 class PayPalVerificationServiceTest extends TestCase {
 

--- a/tests/Unit/Domain/Model/BookingDataTransformers/CreditCardBookingTransformerTest.php
+++ b/tests/Unit/Domain/Model/BookingDataTransformers/CreditCardBookingTransformerTest.php
@@ -11,6 +11,7 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\ValuationDateTimeZone;
 
 /**
  * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\BookingDataTransformers\CreditCardBookingTransformer
+ * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\ValuationDateTimeZone
  */
 class CreditCardBookingTransformerTest extends TestCase {
 

--- a/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
+++ b/tests/Unit/Domain/Model/BookingDataTransformers/PayPalBookingTransformerTest.php
@@ -11,6 +11,7 @@ use WMDE\Fundraising\PaymentContext\Tests\Data\PayPalPaymentBookingData;
 
 /**
  * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\BookingDataTransformers\PayPalBookingTransformer
+ * @covers \WMDE\Fundraising\PaymentContext\Domain\Model\ValuationDateTimeZone
  */
 class PayPalBookingTransformerTest extends TestCase {
 

--- a/tests/Unit/Services/PayPal/PayPalPaymentProviderAdapterTest.php
+++ b/tests/Unit/Services/PayPal/PayPalPaymentProviderAdapterTest.php
@@ -30,6 +30,7 @@ use WMDE\Fundraising\PaymentContext\Tests\Fixtures\FakeUrlAuthenticator;
 /**
  * @covers \WMDE\Fundraising\PaymentContext\Services\PayPal\PayPalPaymentProviderAdapter
  * @covers \WMDE\Fundraising\PaymentContext\Services\PayPal\PayPalPaymentProviderAdapterConfig
+ * @covers \WMDE\Fundraising\PaymentContext\Domain\UrlGenerator\DomainSpecificContext
  */
 class PayPalPaymentProviderAdapterTest extends TestCase {
 	private const ORDER_ID = 'SOME-ORDER-ID';

--- a/tests/Unit/Services/PaymentUrlGenerator/CreditCardURLGeneratorTest.php
+++ b/tests/Unit/Services/PaymentUrlGenerator/CreditCardURLGeneratorTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace Unit\Services\PaymentUrlGenerator;
+namespace WMDE\Fundraising\PaymentContext\Tests\Unit\Services\PaymentUrlGenerator;
 
 use PHPUnit\Framework\TestCase;
 use WMDE\Euro\Euro;
@@ -16,6 +16,7 @@ use WMDE\Fundraising\PaymentContext\Tests\Fixtures\FakeUrlAuthenticator;
 
 /**
  * @covers \WMDE\Fundraising\PaymentContext\Services\PaymentUrlGenerator\CreditCardURLGenerator
+ * @covers \WMDE\Fundraising\PaymentContext\Domain\UrlGenerator\DomainSpecificContext
  */
 class CreditCardURLGeneratorTest extends TestCase {
 

--- a/tests/Unit/UseCases/CreateBookedPayPalPaymentUseCase/CreateBookedPayPalPaymentUseCaseTest.php
+++ b/tests/Unit/UseCases/CreateBookedPayPalPaymentUseCase/CreateBookedPayPalPaymentUseCaseTest.php
@@ -19,6 +19,9 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\SuccessRe
 
 /**
  * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\CreateBookedPayPalPaymentUseCase
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\FailingPaymentIdRepository
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\FailureResponse
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\SuccessResponse
  */
 class CreateBookedPayPalPaymentUseCaseTest extends TestCase {
 	private const PAYMENT_ID = 5;

--- a/tests/Unit/UseCases/CreatePayment/CreatePaymentUseCaseTest.php
+++ b/tests/Unit/UseCases/CreatePayment/CreatePaymentUseCaseTest.php
@@ -32,8 +32,11 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse;
 
 /**
  * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\CreatePaymentUseCase
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\FailureResponse
  * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest
  * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationException
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse
+ * @covers \WMDE\Fundraising\PaymentContext\Domain\UrlGenerator\DomainSpecificContext
  */
 class CreatePaymentUseCaseTest extends TestCase {
 

--- a/tests/Unit/UseCases/CreateSubscriptionPlansForProduct/CreateSubscriptionPlansForProductTest.php
+++ b/tests/Unit/UseCases/CreateSubscriptionPlansForProduct/CreateSubscriptionPlansForProductTest.php
@@ -16,6 +16,9 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreateSubscriptionPlansForProduct\S
 
 /**
  * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateSubscriptionPlansForProduct\CreateSubscriptionPlanForProductUseCase
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateSubscriptionPlansForProduct\CreateSubscriptionPlanRequest
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateSubscriptionPlansForProduct\ErrorResult
+ * @covers \WMDE\Fundraising\PaymentContext\UseCases\CreateSubscriptionPlansForProduct\SuccessResult
  */
 class CreateSubscriptionPlansForProductTest extends TestCase {
 


### PR DESCRIPTION
Increase coverage by adding `@covers` tags for value objects in tests
where those value objects are used.
