### PR TITLE
Update Deptrac to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"wmde/inspector-generator": "dev-main",
 		"phpstan/phpstan": "~1.3",
 		"phpstan/phpstan-phpunit": "^1.0",
-        "qossmic/deptrac-shim": "^1.0",
+        "qossmic/deptrac": "^2.0",
         "wmde/psr-log-test-doubles": "~v3.2.0"
 	},
 	"repositories": [
@@ -58,6 +58,11 @@
 	"extra": {
 		"branch-alias": {
 			"dev-main": "7.0.x-dev"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }


### PR DESCRIPTION
With the release of 2.0 Deptrac can now be installed regularly with
composer, omitting the "shim".

Dependency tracking still passes, no other changes needed.
