### PR TITLE
 Add test matrix to the Woodpecker CI config

### DIFF
--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -9,11 +9,16 @@ clone:
       depth: 10
       lfs: false
 
+matrix:
+  CONTAINER_IMAGE:
+    - registry.gitlab.com/fun-tech/fundraising-frontend-docker:latest
+    - registry.gitlab.com/fun-tech/fundraising-frontend-docker/php-8.4:latest
+
 steps:
   - name: build
     when:
       - event: [ push, pull_request, cron, manual ]
-    image: registry.gitlab.com/fun-tech/fundraising-frontend-docker:latest
+    image: ${CONTAINER_IMAGE}
     environment:
       COMPOSER_CACHE_DIR: /composer_cache
       TEST_DB_DSN: mysql://fundraising:T3st1ng@database:3306/fundraising


### PR DESCRIPTION
- the test matrix allows us to run our workflow with seperate images https://woodpecker-ci.org/docs/usage/matrix-workflows#example-matrix-pipeline-based-on-docker-image-tag
- part of the update to php8.4

Ticket https://phabricator.wikimedia.org/T387970