### PR TITLE
Add FeeChange Payment Type

### DIFF
--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.FeeChangePayment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.FeeChangePayment.dcm.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\FeeChangePayment"/>
+</doctrine-mapping>

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.Payment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.Payment.dcm.xml
@@ -8,6 +8,7 @@
             <discriminator-mapping value="BEZ" class="WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment"/>
             <discriminator-mapping value="UEB" class="WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment"/>
             <discriminator-mapping value="SUB" class="WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment"/>
+            <discriminator-mapping value="FCH" class="WMDE\Fundraising\PaymentContext\Domain\Model\FeeChangePayment"/>
         </discriminator-map>
         <id name="id" type="integer" column="id">
             <generator strategy="NONE"/>

--- a/src/Domain/Model/FeeChangePayment.php
+++ b/src/Domain/Model/FeeChangePayment.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\PaymentContext\Domain\Model;
+
+use WMDE\Euro\Euro;
+
+class FeeChangePayment extends Payment {
+	/**
+	 * This payment is meant for functionality where a donor or member wants to update their payment information without giving more payment details.
+	 * It **must not** be used as the payment when creating donations or memberships!
+	 */
+	private const PAYMENT_METHOD = 'FCH';
+
+	private function __construct( int $id, Euro $amount, PaymentInterval $interval ) {
+		parent::__construct( $id, $amount, $interval, self::PAYMENT_METHOD );
+	}
+
+	public static function create( int $id, Euro $amount, PaymentInterval $interval ): self {
+		return new self( $id, $amount, $interval );
+	}
+
+	public function anonymise(): void {
+	}
+
+	protected function getPaymentName(): string {
+		return self::PAYMENT_METHOD;
+	}
+
+	protected function getPaymentSpecificLegacyData(): array {
+		return [];
+	}
+
+	public function isCompleted(): bool {
+		return true;
+	}
+}

--- a/src/Domain/PaymentType.php
+++ b/src/Domain/PaymentType.php
@@ -9,4 +9,5 @@ enum PaymentType: string {
 	case CreditCard = 'MCP';
 	case Paypal = 'PPL';
 	case Sofort = 'SUB';
+	case FeeChange = 'FCH';
 }

--- a/src/UseCases/CreatePayment/CreatePaymentUseCase.php
+++ b/src/UseCases/CreatePayment/CreatePaymentUseCase.php
@@ -7,6 +7,7 @@ use WMDE\Euro\Euro;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\FeeChangePayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Payment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
@@ -72,6 +73,7 @@ class CreatePaymentUseCase {
 			PaymentType::Sofort => $this->createSofortPayment( $parameters ),
 			PaymentType::BankTransfer => $this->createBankTransferPayment( $parameters ),
 			PaymentType::DirectDebit => $this->createDirectDebitPayment( $parameters ),
+			PaymentType::FeeChange => $this->createFeeChangePayment( $parameters ),
 			default => throw new \LogicException( sprintf(
 				'Invalid payment type not caught by %s: %s', PaymentValidator::class, $parameters->paymentType
 			) )
@@ -147,6 +149,14 @@ class CreatePaymentUseCase {
 			PaymentInterval::from( $parameters->interval ),
 			new Iban( $parameters->iban ),
 			$parameters->bic
+		);
+	}
+
+	private function createFeeChangePayment( PaymentParameters $parameters ): FeeChangePayment {
+		return FeeChangePayment::create(
+			$this->idGenerator->getNewId(),
+			Euro::newFromCents( $parameters->amountInEuroCents ),
+			PaymentInterval::from( $parameters->interval ),
 		);
 	}
 


### PR DESCRIPTION
We need to collect payments when a member updates
only their fee and amount. These columns exist in
the Payment table but each of the other types have
extra data that we don't need. This adds an empty
type to allow us to collect the payment changes
without adding a new table.

Ticket: https://phabricator.wikimedia.org/T395015