### PR TITLE
Add migration to create fee change table

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-main": "7.0.x-dev"
+			"dev-main": "8.2.x-dev"
 		}
 	},
 	"config": {

--- a/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.FeeChangePayment.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.PaymentContext.Domain.Model.FeeChangePayment.dcm.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\FeeChangePayment"/>
+    <entity name="WMDE\Fundraising\PaymentContext\Domain\Model\FeeChangePayment" table="payment_fee_change"/>
 </doctrine-mapping>

--- a/migrations-db.php
+++ b/migrations-db.php
@@ -1,0 +1,11 @@
+<?php
+
+// This is the migration configuration for testing out the migrations
+
+return [
+    'dbname' => 'fundraising',
+    'user' => 'fundraising',
+    'password' => 'INSECURE PASSWORD',
+    'host' => 'database',
+    'driver' => 'pdo_mysql',
+];

--- a/migrations.php
+++ b/migrations.php
@@ -1,0 +1,24 @@
+<?php
+
+// This is the migrations configuration file for developing migrations locally
+// DO NOT USE THIS IN PRODUCTION
+
+return [
+    'table_storage' => [
+        'table_name' => 'doctrine_migration_versions',
+        'version_column_name' => 'version',
+        'version_column_length' => 1024,
+        'executed_at_column_name' => 'executed_at',
+        'execution_time_column_name' => 'execution_time',
+    ],
+
+    'migrations_paths' => [
+        'WMDE\Fundraising\PaymentContext\DataAccess\Migrations' => './src/DataAccess/Migrations',
+    ],
+
+    'all_or_nothing' => true,
+    'organize_migrations' => 'none',
+    'connection' => null,
+    'em' => null,
+];
+

--- a/src/DataAccess/Migrations/Version20250916164428.php
+++ b/src/DataAccess/Migrations/Version20250916164428.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\PaymentContext\DataAccess\Migrations;
+
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250916164428 extends AbstractMigration {
+	private const string TABLE_NAME = 'payment_fee_change';
+
+	public function getDescription(): string {
+		return 'Create FeeChange payment table';
+	}
+
+	public function up( Schema $schema ): void {
+		$feeChange = $schema->createTable( self::TABLE_NAME );
+		$feeChange->addColumn( 'id', Types::INTEGER );
+		$feeChange->addPrimaryKeyConstraint( PrimaryKeyConstraint::editor()
+			->setUnquotedColumnNames( 'id' )
+			->create()
+		);
+		$feeChange->addForeignKeyConstraint(
+			'payment',
+			[ 'id' ],
+			[ 'id' ],
+			[ 'onDelete' => 'CASCADE' ],
+			'FK_A072317DBF396750'
+		);
+	}
+
+	public function down( Schema $schema ): void {
+		$schema->dropTable( self::TABLE_NAME );
+	}
+}


### PR DESCRIPTION
- Add a table name to the mapping file to conform with our other table
  names.
- Add migration configuration files
- Add migration that creates the `payment_fee_change` table

This is a followup for #215

Ticket: https://phabricator.wikimedia.org/T395015

**Integration instructions:** When updating the fundraising application, re-run `make generate-database-schema` to refresh the SQL file. That will take care of the renamed table.
