### PR TITLE
Scrub Sofort Transaction ID

### DIFF
--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -55,11 +55,11 @@ class SofortPayment extends Payment implements BookablePayment {
 	}
 
 	public function isBooked(): bool {
-		return $this->valuationDate !== null && $this->transactionId !== null;
+		return $this->valuationDate !== null;
 	}
 
 	public function canBeBooked( array $transactionData ): bool {
-		return $this->transactionId === null;
+		return $this->valuationDate === null;
 	}
 
 	/**
@@ -127,5 +127,6 @@ class SofortPayment extends Payment implements BookablePayment {
 
 	public function scrubPersonalData(): void {
 		$this->paymentReferenceCode = null;
+		$this->transactionId = null;
 	}
 }

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -100,7 +100,7 @@ class SofortPaymentTest extends TestCase {
 		$this->assertSame( [ 'ueb_code' => 'XW-DAR-E99-X' ], $legacyData->paymentSpecificValues );
 	}
 
-	public function testAnonymisedPaymentHasEmptyReferenceCodeInLegacyData(): void {
+	public function testScrubbedPaymentHasClearsLegacyData(): void {
 		$sofortPayment = $this->makeSofortPayment();
 		$sofortPayment->scrubPersonalData();
 
@@ -138,6 +138,31 @@ class SofortPaymentTest extends TestCase {
 
 		$this->assertNotNull( $payment->getValuationDate() );
 		$this->assertFalse( $payment->canBeBooked( [] ) );
+		$this->assertEquals( $expectedOutput, $payment->getDisplayValues() );
+	}
+
+	public function testScrubbedPaymentCannotBeReBooked(): void {
+		$payment = $this->makeSofortPayment();
+		$payment->bookPayment( $this->makeValidTransactionData(), new DummyPaymentIdRepository() );
+		$payment->scrubPersonalData();
+
+		$this->assertFalse( $payment->canBeBooked( [] ) );
+	}
+
+	public function testGetDisplayDataOnScrubbedPaymentReturnsFieldsToDisplay(): void {
+		$payment = $this->makeSofortPayment();
+		$payment->bookPayment( $this->makeValidTransactionData(), new DummyPaymentIdRepository() );
+		$payment->scrubPersonalData();
+
+		$expectedOutput = [
+			'amount' => 1000,
+			'interval' => 0,
+			'paymentType' => 'SUB',
+			'paymentReferenceCode' => '',
+			'valuationDate' => '2001-12-24 17:30:00'
+		];
+
+		$this->assertNotNull( $payment->getValuationDate() );
 		$this->assertEquals( $expectedOutput, $payment->getDisplayValues() );
 	}
 


### PR DESCRIPTION
We clear the Sofort transaction ID when a payment is
scrubbed so it can't be linked back to any donor
data in Sofort.

https://phabricator.wikimedia.org/T426156