### PR TITLE
Scrub Paypal Data

### DIFF
--- a/src/Domain/Model/PayPalPayment.php
+++ b/src/Domain/Model/PayPalPayment.php
@@ -35,7 +35,7 @@ class PayPalPayment extends Payment implements BookablePayment {
 	}
 
 	public function isBooked(): bool {
-		return $this->valuationDate !== null && !empty( $this->bookingData );
+		return $this->valuationDate !== null;
 	}
 
 	public function canBeBooked( array $transactionData ): bool {
@@ -78,7 +78,7 @@ class PayPalPayment extends Payment implements BookablePayment {
 
 	protected function getPaymentSpecificLegacyData(): array {
 		$legacyData = [];
-		if ( $this->isBooked() ) {
+		if ( !empty( $this->bookingData ) ) {
 			$legacyData = ( new PayPalBookingTransformer( $this->bookingData ) )->getLegacyData();
 		}
 		if ( $this->parentPayment !== null ) {
@@ -120,5 +120,10 @@ class PayPalPayment extends Payment implements BookablePayment {
 
 	public function getParentPayment(): ?PayPalPayment {
 		return $this->parentPayment;
+	}
+
+	public function scrubPersonalData(): void {
+		$this->transactionId = null;
+		$this->bookingData = [];
 	}
 }

--- a/tests/Unit/Domain/Model/PayPalPaymentTest.php
+++ b/tests/Unit/Domain/Model/PayPalPaymentTest.php
@@ -66,6 +66,14 @@ class PayPalPaymentTest extends TestCase {
 		$this->assertTrue( $payment->canBeBooked( PayPalPaymentBookingData::newValidFollowupBookingData() ) );
 	}
 
+	public function testInitialPaymentCanBeBookedAsFollowupPaymentAfterScrubbing(): void {
+		$payment = new PayPalPayment( 1, Euro::newFromCents( 1000 ), PaymentInterval::Monthly );
+		$payment->bookPayment( PayPalPaymentBookingData::newValidBookingData(), new DummyPaymentIdRepository() );
+		$payment->scrubPersonalData();
+
+		$this->assertTrue( $payment->canBeBooked( PayPalPaymentBookingData::newValidFollowupBookingData() ) );
+	}
+
 	public function testBookingABookedParentPaymentCreatesABookedChildPayment(): void {
 		$payment = new PayPalPayment( 1, Euro::newFromCents( 1000 ), PaymentInterval::Monthly );
 		$payment->bookPayment( PayPalPaymentBookingData::newValidBookingData(), new DummyPaymentIdRepository() );
@@ -177,6 +185,32 @@ class PayPalPaymentTest extends TestCase {
 		$this->assertNotNull( $payment->getValuationDate() );
 		$this->assertFalse( $payment->canBeBooked( [] ) );
 		$this->assertEquals( $expectedOutput, $actualDisplayData );
+	}
+
+	public function testGetDisplayDataForScrubbedPaymentReturnsFields(): void {
+		$payment = new PayPalPayment( 1, Euro::newFromCents( 1000 ), PaymentInterval::OneTime );
+		$payment->bookPayment( PayPalPaymentBookingData::newValidBookingData(), new DummyPaymentIdRepository() );
+		$payment->scrubPersonalData();
+
+		$expectedOutput = [
+			'amount' => 1000,
+			'interval' => 0,
+			'paymentType' => 'PPL',
+		];
+
+		$actualDisplayData = $payment->getDisplayValues();
+
+		$this->assertNotNull( $payment->getValuationDate() );
+		$this->assertFalse( $payment->canBeBooked( [] ) );
+		$this->assertEquals( $expectedOutput, $actualDisplayData );
+	}
+
+	public function testScrubbedPaymentHasNoTransactionId(): void {
+		$payment = new PayPalPayment( 1, Euro::newFromCents( 1000 ), PaymentInterval::OneTime );
+		$payment->bookPayment( PayPalPaymentBookingData::newValidBookingData(), new DummyPaymentIdRepository() );
+		$payment->scrubPersonalData();
+
+		$this->assertNull( $payment->getTransactionId() );
 	}
 
 	private function makeIdGeneratorForFollowupPayments(): PaymentIdRepository {


### PR DESCRIPTION
Hook up the scrubPersonalData() method in the paypal model
and adjust evaluations to work with a scrubbed payment. Add
tests.

Ticket: https://phabricator.wikimedia.org/T426152