### PR TITLE
Add more info to payment legacy data

### DIFF
--- a/src/Domain/Model/CreditCardPayment.php
+++ b/src/Domain/Model/CreditCardPayment.php
@@ -65,10 +65,13 @@ class CreditCardPayment extends Payment implements BookablePayment {
 
 	protected function getPaymentSpecificLegacyData(): array {
 		if ( $this->bookingData === [] ) {
-			return [];
+			$legacyData = [];
+		} else {
+			$legacyData = ( new CreditCardBookingTransformer( $this->bookingData ) )->getLegacyData();
 		}
 
-		return ( new CreditCardBookingTransformer( $this->bookingData ) )->getLegacyData();
+		$legacyData[ 'is_booked' ] = $this->isBooked();
+		return $legacyData;
 	}
 
 	public function getDisplayValues(): array {

--- a/src/Domain/Model/PayPalPayment.php
+++ b/src/Domain/Model/PayPalPayment.php
@@ -84,6 +84,7 @@ class PayPalPayment extends Payment implements BookablePayment {
 		if ( $this->parentPayment !== null ) {
 			$legacyData['parent_payment_id'] = $this->parentPayment->getId();
 		}
+		$legacyData[ 'is_booked' ] = $this->isBooked();
 		return $legacyData;
 	}
 

--- a/src/Domain/Model/SofortPayment.php
+++ b/src/Domain/Model/SofortPayment.php
@@ -101,6 +101,7 @@ class SofortPayment extends Payment implements BookablePayment {
 		] );
 		// always have the payment reference code in here, to enable override of existing code, just in case.
 		$data['ueb_code'] = $this->paymentReferenceCode ? $this->paymentReferenceCode->getFormattedCode() : '';
+		$data['is_booked'] = $this->isBooked();
 		return $data;
 	}
 

--- a/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrinePaymentRepositoryTest.php
@@ -163,6 +163,7 @@ class DoctrinePaymentRepositoryTest extends TestCase {
 			'ext_payment_status' => 'processed/express_checkout',
 			'ext_payment_account' => '42DFPNJDF8RED',
 			'ext_payment_timestamp' => '10:54:49 Dec 02, 2012 PST',
+			'is_booked' => true,
 		], $payment->getDisplayValues() );
 
 		$this->assertSame( 1, $followupPayment->getLegacyData()->paymentSpecificValues['parent_payment_id'] );

--- a/tests/Unit/Domain/Model/CreditCardPaymentTest.php
+++ b/tests/Unit/Domain/Model/CreditCardPaymentTest.php
@@ -98,7 +98,7 @@ class CreditCardPaymentTest extends TestCase {
 	public function testGivenNewPayment_paymentLegacyDataIsEmptyArray(): void {
 		$creditCardPayment = new CreditCardPayment( 1, Euro::newFromInt( 1000 ), PaymentInterval::Monthly );
 
-		$this->assertSame( [], $creditCardPayment->getLegacyData()->paymentSpecificValues );
+		$this->assertSame( [ 'is_booked' => false ], $creditCardPayment->getLegacyData()->paymentSpecificValues );
 	}
 
 	public function testGetDisplayDataReturnsAllFieldsToDisplayForBookedPayment(): void {
@@ -118,7 +118,8 @@ class CreditCardPaymentTest extends TestCase {
 			'mcp_country' => 'DE',
 			'mcp_currency' => 'EUR',
 			'mcp_cc_expiry_date' => '',
-			'ext_payment_status' => 'processed'
+			'ext_payment_status' => 'processed',
+			'is_booked' => true,
 		];
 
 		$actualDisplayData = $creditCardPayment->getDisplayValues();
@@ -145,7 +146,8 @@ class CreditCardPaymentTest extends TestCase {
 		$expectedOutput = [
 			'amount' => 100000,
 			'interval' => 1,
-			'paymentType' => 'MCP'
+			'paymentType' => 'MCP',
+			'is_booked' => true,
 		];
 
 		$this->assertNotNull( $payment->getValuationDate() );

--- a/tests/Unit/Domain/Model/PayPalPaymentTest.php
+++ b/tests/Unit/Domain/Model/PayPalPaymentTest.php
@@ -124,7 +124,7 @@ class PayPalPaymentTest extends TestCase {
 
 		$legacyData = $payment->getLegacyData();
 
-		$this->assertSame( [], $legacyData->paymentSpecificValues );
+		$this->assertSame( [ 'is_booked' => false ], $legacyData->paymentSpecificValues );
 		$this->assertSame( 'PPL', $legacyData->paymentName );
 	}
 
@@ -177,7 +177,8 @@ class PayPalPaymentTest extends TestCase {
 			'ext_payment_type' => 'instant',
 			'ext_payment_status' => 'processed/express_checkout',
 			'ext_payment_account' => '42DFPNJDF8RED',
-			'ext_payment_timestamp' => PayPalPaymentBookingData::PAYMENT_DATE
+			'ext_payment_timestamp' => PayPalPaymentBookingData::PAYMENT_DATE,
+			'is_booked' => true,
 		];
 
 		$actualDisplayData = $payment->getDisplayValues();
@@ -196,6 +197,7 @@ class PayPalPaymentTest extends TestCase {
 			'amount' => 1000,
 			'interval' => 0,
 			'paymentType' => 'PPL',
+			'is_booked' => true,
 		];
 
 		$actualDisplayData = $payment->getDisplayValues();

--- a/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -97,7 +97,7 @@ class SofortPaymentTest extends TestCase {
 
 		$legacyData = $sofortPayment->getLegacyData();
 
-		$this->assertSame( [ 'ueb_code' => 'XW-DAR-E99-X' ], $legacyData->paymentSpecificValues );
+		$this->assertSame( [ 'ueb_code' => 'XW-DAR-E99-X', 'is_booked' => false ], $legacyData->paymentSpecificValues );
 	}
 
 	public function testScrubbedPaymentHasClearsLegacyData(): void {
@@ -106,7 +106,7 @@ class SofortPaymentTest extends TestCase {
 
 		$legacyData = $sofortPayment->getLegacyData();
 
-		$this->assertSame( [ 'ueb_code' => '' ], $legacyData->paymentSpecificValues );
+		$this->assertSame( [ 'ueb_code' => '', 'is_booked' => false ], $legacyData->paymentSpecificValues );
 	}
 
 	public function testBookedPaymentHasTransactionDataInLegacyData(): void {
@@ -115,7 +115,8 @@ class SofortPaymentTest extends TestCase {
 		$expectedLegacyData = [
 			'ueb_code' => 'XW-DAR-E99-X',
 			'transaction_id' => 'yellow',
-			'valuation_date' => '2001-12-24 17:30:00'
+			'valuation_date' => '2001-12-24 17:30:00',
+			'is_booked' => true
 		];
 
 		$legacyData = $sofortPayment->getLegacyData();
@@ -133,7 +134,8 @@ class SofortPaymentTest extends TestCase {
 			'paymentType' => 'SUB',
 			'paymentReferenceCode' => 'XW-DAR-E99-X',
 			'transactionId' => 'yellow',
-			'valuationDate' => '2001-12-24 17:30:00'
+			'valuationDate' => '2001-12-24 17:30:00',
+			'is_booked' => true
 		];
 
 		$this->assertNotNull( $payment->getValuationDate() );
@@ -159,7 +161,8 @@ class SofortPaymentTest extends TestCase {
 			'interval' => 0,
 			'paymentType' => 'SUB',
 			'paymentReferenceCode' => '',
-			'valuationDate' => '2001-12-24 17:30:00'
+			'valuationDate' => '2001-12-24 17:30:00',
+			'is_booked' => true
 		];
 
 		$this->assertNotNull( $payment->getValuationDate() );


### PR DESCRIPTION
The donation bounded context uses the legacy
payment data to determine the state of a
donation that has a bookable payment based
on if the payment was booked by using the
payment's id or valuation date.

But now we scrub payments this data is removed,
so this adds a new item to the legacy data
that holds the booked state.